### PR TITLE
ON-15682: update for ef_vi sub-nanosecond timestamp API

### DIFF
--- a/src/include/zf_internal/timestamping.h
+++ b/src/include/zf_internal/timestamping.h
@@ -43,8 +43,13 @@ __zfr_pkt_get_timestamp(struct zf_stack* st, const char* pkt,
 
   /* Call ..._internal directly as we store the current timesync
    * values in the packet not the evq */
-  return ef10_receive_get_timestamp_with_sync_flags_internal
-    (vi, pkt, ts_out, flags_out, tsync_minor, tsync_major);
+  ef_precisetime ts;
+  int rc = ef10_receive_get_precise_timestamp_internal
+    (vi, pkt, &ts, tsync_minor, tsync_major);
+  ts_out->tv_sec = ts.tv_sec;
+  ts_out->tv_nsec = ts.tv_nsec;
+  *flags_out = ts.tv_flags;
+  return rc;
 }
 
 


### PR DESCRIPTION
Fix regression found building unit test suite due to ef_vi's new sub-nanosecond resolution timestamping API (Xilinx-CNS/onload@9bd12fde14).

### Failure

```
cc build/gnu_x86_64-zf-devel/obj/tests/zf_unit//efrxtimestamping.o build/gnu_x86_64-zf-devel/obj/tests/zf_unit//../tap/tap.o build/gnu_x86_64-zf-devel/lib/libonload_zf_static.a -lm -lpthread -lrt -lstdc++ -o build/gnu_x86_64-zf-devel/bin/zf_unit/efrxtimestamping
/usr/bin/ld: build/gnu_x86_64-zf-devel/obj/tests/zf_unit//efrxtimestamping.o: in function `get_timestamp_qns(int, unsigned int, unsigned int, unsigned int)':
/home/okt-yuri/work/tcpdirect/src/tests/zf_unit//efrxtimestamping.c:99: undefined reference to `ef10_receive_get_timestamp_with_sync_flags_internal'
/usr/bin/ld: build/gnu_x86_64-zf-devel/obj/tests/zf_unit//efrxtimestamping.o: in function `get_timestamp_27(int, unsigned int, unsigned int, unsigned int)':
/home/okt-yuri/work/tcpdirect/src/tests/zf_unit//efrxtimestamping.c:99: undefined reference to `ef10_receive_get_timestamp_with_sync_flags_internal'
/usr/bin/ld: build/gnu_x86_64-zf-devel/lib/libonload_zf_static.a: in function `zfur_pkt_get_timestamp':
/home/okt-yuri/work/tcpdirect/src/include/zf_internal/timestamping.h:47: undefined reference to `ef10_receive_get_timestamp_with_sync_flags_internal'
/usr/bin/ld: build/gnu_x86_64-zf-devel/lib/libonload_zf_static.a: in function `__zfr_pkt_get_timestamp(zf_stack*, char const*, timespec*, unsigned int*)':
/home/okt-yuri/work/tcpdirect/src/include/zf_internal/timestamping.h:47: undefined reference to `ef10_receive_get_timestamp_with_sync_flags_internal'
/usr/bin/ld: build/gnu_x86_64-zf-devel/lib/libonload_zf_static.a: in function `zft_pkt_get_timestamp':
/home/okt-yuri/work/tcpdirect/src/include/zf_internal/timestamping.h:47: undefined reference to `ef10_receive_get_timestamp_with_sync_flags_internal'
collect2: error: ld returned 1 exit status
make: *** [src/tests/zf_unit/Makefile.inc:74: build/gnu_x86_64-zf-devel/bin/zf_unit/efrxtimestamping] Error 1
```

### Testing done
```
[16:08:38] build/gnu_x86_64-zf-devel/bin/zf_unit/zftest ............. ok       25 ms ( 0.00 usr  0.00 sys +  0.00 cusr  0.01 csys =  0.01 CPU)
[16:08:38] build/gnu_x86_64-zf-devel/bin/zf_unit/zfinit ............. ok      665 ms ( 0.00 usr  0.00 sys +  0.32 cusr  0.43 csys =  0.75 CPU)
[16:08:38] build/gnu_x86_64-zf-devel/bin/zf_unit/zfudprx ............ ok      489 ms ( 0.03 usr  0.00 sys +  0.11 cusr  0.36 csys =  0.50 CPU)
[16:08:39] build/gnu_x86_64-zf-devel/bin/zf_unit/zf_superbuf_reuse .. ok      486 ms ( 0.00 usr  0.00 sys +  0.12 cusr  0.37 csys =  0.49 CPU)
[16:08:39] build/gnu_x86_64-zf-devel/bin/zf_unit/zftcprx ............ ok    48772 ms ( 0.06 usr  0.00 sys + 96.53 cusr  0.37 csys = 96.96 CPU)
[16:09:28] build/gnu_x86_64-zf-devel/bin/zf_unit/zftcpcopyrx ........ ok      604 ms ( 0.00 usr  0.00 sys +  0.35 cusr  0.36 csys =  0.71 CPU)
[16:09:29] build/gnu_x86_64-zf-devel/bin/zf_unit/zftcptx ............ ok      498 ms ( 0.02 usr  0.00 sys +  0.11 cusr  0.37 csys =  0.50 CPU)
[16:09:29] build/gnu_x86_64-zf-devel/bin/zf_unit/zfmulticast ........ ok      472 ms ( 0.00 usr  0.00 sys +  0.11 cusr  0.36 csys =  0.47 CPU)
[16:09:30] build/gnu_x86_64-zf-devel/bin/zf_unit/zftcp_muxer ........ ok      486 ms ( 0.00 usr  0.00 sys +  0.11 cusr  0.37 csys =  0.48 CPU)
[16:09:30] build/gnu_x86_64-zf-devel/bin/zf_unit/zfds ............... ok      496 ms ( 0.00 usr  0.00 sys +  0.11 cusr  0.38 csys =  0.49 CPU)
[16:09:31] build/gnu_x86_64-zf-devel/bin/zf_unit/efrxtimestamping ... ok       46 ms ( 0.01 usr  0.00 sys +  0.02 cusr  0.01 csys =  0.04 CPU)
[16:09:31] build/gnu_x86_64-zf-devel/bin/zf_unit/zftimestamping ..... Dubious, test returned 1 (wstat 256, 0x100)
Failed 6/1562 subtests 
[16:09:32] build/gnu_x86_64-zf-devel/bin/zf_unit/zftcprx_on14495 .... ok      472 ms ( 0.00 usr  0.00 sys +  0.10 cusr  0.37 csys =  0.47 CPU)
[16:09:33]

Test Summary Report
-------------------
build/gnu_x86_64-zf-devel/bin/zf_unit/zftcptx          (Wstat: 0 Tests: 369 Failed: 0)
  TODO passed:   275, 277, 279, 281, 283, 285, 287, 289
                291, 293, 295, 297, 299, 301, 303, 305
                307, 309, 311, 313, 315, 317, 319, 321
                323, 325, 327, 329, 331, 333, 335, 337
                339, 341, 343, 345, 347, 349, 351, 353
                355, 357, 359, 361, 363, 365, 368
build/gnu_x86_64-zf-devel/bin/zf_unit/zftimestamping   (Wstat: 256 Tests: 1562 Failed: 6)
  Failed tests:  2-3, 522-523, 1039-1040
  Non-zero exit status: 1
Files=13, Tests=3722, 55 wallclock secs ( 0.20 usr  0.02 sys + 99.08 cusr  4.13 csys = 103.43 CPU)
Result: FAIL
```

I understand that the `zftimestamping` partial failure is currently an expected test reliability issue and thought probably not to be a regression.