### PR TITLE
cleanup: CI tweaks

### DIFF
--- a/.github/workflows/perform_build.yml
+++ b/.github/workflows/perform_build.yml
@@ -3,7 +3,10 @@
 
 name: "perform_build"
 
-on: push
+on:
+  push:
+  pull_request:
+    types: [opened]
 
 jobs:
   extract_branch_info:
@@ -29,7 +32,6 @@ jobs:
         id: tcpdirectBranch
         run: echo "branch=$(yq -r '.products.TCPDirect.version' < $GITHUB_WORKSPACE/tcpdirect/versions.yaml)" >> "$GITHUB_OUTPUT"
 
-
       - name: Extract onload branch name
         id: onloadBranch
         run: echo "branch=$(yq -r '.products.Onload.version' < $GITHUB_WORKSPACE/tcpdirect/versions.yaml)" >> "$GITHUB_OUTPUT"
@@ -53,13 +55,13 @@ jobs:
       - name: onload checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.repository_owner }}/onload_internal
-          path: onload_internal
-          ssh-key: ${{ secrets.ONLOAD_INTERNAL_PRIVATE_KEY }}
+          repository: ${{ github.repository_owner }}/onload
+          path: onload
           ref: ${{ needs.extract_branch_info.outputs.onloadBranch }}
 
       - name: packetdrill checkout
         uses: actions/checkout@v4
+        continue-on-error: true
         with:
           repository: ${{ github.repository_owner }}/packetdrill-tcpdirect
           path: packetdrill-tcpdirect
@@ -71,18 +73,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential perl
 
-
       - name: build
         run: |
           cd $GITHUB_WORKSPACE/tcpdirect
-          ONLOAD_TREE=$GITHUB_WORKSPACE/onload_internal NDEBUG=1 make -j $(nproc)
+          ONLOAD_TREE=$GITHUB_WORKSPACE/onload NDEBUG=1 make -j $(nproc)
 
       - name: shim
         run: |
           cd $GITHUB_WORKSPACE/tcpdirect
-          ONLOAD_TREE=$GITHUB_WORKSPACE/onload_internal NDEBUG=1 ZF_DEVEL=1 TEST_THREAD_NAME=zf make -j $(nproc) shim
+          ONLOAD_TREE=$GITHUB_WORKSPACE/onload NDEBUG=1 ZF_DEVEL=1 TEST_THREAD_NAME=zf make -j $(nproc) shim
 
       - name: tests
         run: |
           cd $GITHUB_WORKSPACE/tcpdirect
-          ONLOAD_TREE=$GITHUB_WORKSPACE/onload_internal NDEBUG=1 ZF_DEVEL=1 TEST_THREAD_NAME=zf make -j $(nproc) test
+          ONLOAD_TREE=$GITHUB_WORKSPACE/onload UT_OUTPUT=$GITHUB_STEP_SUMMARY NDEBUG=1 ZF_DEVEL=1 TEST_THREAD_NAME=zf make -j $(nproc) -k test

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ include src/tests/zf_apps/Makefile.inc
 include src/tests/zf_internal/Makefile.inc
 
 # We use packetdrill for some tests, but can cope without it if not present
-ifneq ("$(wildcard ../packetdrill-tcpdirect)", "")
+ifneq ("$(wildcard ../packetdrill-tcpdirect/Makefile.inc)", "")
 	include ../packetdrill-tcpdirect/Makefile.inc
 endif
 

--- a/ci/test.groovy
+++ b/ci/test.groovy
@@ -159,13 +159,16 @@ nm.slack_notify() {
           dir('test-results') { // ensure folder exists
           }
           // Makefiles do not support gcov build yet
-          sh """#!/bin/bash
+          def rc = sh(script: """#!/bin/bash
             export CC=${CC}
             export ONLOAD_TREE=\$PWD/onload
             export ZF_DEVEL=1
             export TEST_THREAD_NAME=zf
             make -k -C tcpdirect test_jenkins
-          """
+          """, returnStatus: true)
+          if (rc != 0) {
+            unstable("not all tests passed")
+          }
         }
       },
     )

--- a/src/include/zf_internal/utils.h
+++ b/src/include/zf_internal/utils.h
@@ -25,6 +25,7 @@ struct zf_pool;
   do {                                                                      \
     zf_log(NULL, "FAIL at %s:%d\n", __FILE__, __LINE__);                    \
     zf_backtrace();                                                         \
+    fflush(stdout);                                                         \
     abort();                                                                \
   } while(0)
 
@@ -161,6 +162,7 @@ struct zf_pool;
       fprintf(stderr, "ERROR: at %s:%d\n", __FILE__, __LINE__);         \
       fprintf(stderr, "ERROR: rc=%d errno=%d (%s)\n",                   \
               __rc, errno, strerror(errno));                            \
+      fflush(stdout);                                                   \
       abort();                                                          \
     };                                                                  \
     if(ZF_UNLIKELY( __rc < 0 )) {                                       \
@@ -174,6 +176,7 @@ struct zf_pool;
     auto __report = [&]() ZF_COLD ZF_NOINLINE {                         \
       fprintf(stderr, "ERROR: %s: ZF_TEST(%s) failed\n", __func__, #x); \
       fprintf(stderr, "ERROR: at %s:%d\n", __FILE__, __LINE__);         \
+      fflush(stdout);                                                   \
       abort();                                                          \
     };                                                                  \
     if(ZF_UNLIKELY( ! (x) )) {                                          \

--- a/src/tests/zf_unit/Makefile.inc
+++ b/src/tests/zf_unit/Makefile.inc
@@ -171,32 +171,9 @@ $(UT_SCRIPT_BINS): $(UT_BINDIR)/%: $(SRC_CURRENT)/%
 # Notably it enforces copying the scripts everytime...
 .PHONY: $(UT_SCRIPT_BINS)
 $(UT_SCRIPT_BINS): zf_apps $(UT_BINDIR)/zftcppingpong2
-ifdef UT_OUTPUT
-UT_OUTPUT_DIR = $(UT_OUTPUT)
 
-$(filter-out run_%,$(UT_ALL_TARGETS)): | $(UT_OUTPUT_DIR)
-
-$(UT_OUTPUT_DIR):
-	mkdir -p $(UT_OUTPUT_DIR)/valgrind
-#moved valgrind results to separate folder to avoid junit accesing them
-	rm -rf $(UT_OUTPUT)/valgrind/*.xml
-	rm -rf $(UT_OUTPUT)/*.xml
-endif # UT_OUTPUT
-
-ifdef VALGRIND
-VALGRIND_FLAGS = valgrind --tool=memcheck --read-var-info=yes \
-		 --fair-sched=yes --track-fds=yes --xml=yes \
-		 --xml-file=$(UT_OUTPUT_DIR)/valgrind/$@_%p.xml\
-		 --show-mismatched-frees=yes --trace-children=yes\
-		 --undef-value-errors=yes --track-origins=yes \
-		 --leak-check=full --show-leak-kinds=all
-#As these are nightly tests given bit more time to avoid unnecessary timeouts.
-HARNESS_TIME_OUT=10800
-TEST_TIME_OUT=600
-else
 HARNESS_TIME_OUT=480
 TEST_TIME_OUT=120
-endif
 
 $(call target_variants,testloop): $(UT_LOOP:%=$(UT_BINDIR)/%)
 $(call target_variants,testloop2): $(UT_LOOP2:%=$(UT_BINDIR)/%)
@@ -211,7 +188,7 @@ $(call target_variants,testpacketdrill): $(filter %packetdrill.sh,$(UT_SCRIPT_BI
 
 # for phony targets it does not matter whether dependencies are order-only or not
 # However order-only dependencies are out of $^ which makes recipes simpler.
-ifeq ("$(wildcard ../packetdrill-tcpdirect)", "")
+ifeq ("$(wildcard ../packetdrill-tcpdirect/Makefile.inc)", "")
   packetdrill: ;
 endif
 $(call target_explode,testpacketdrill): | shim packetdrill
@@ -228,22 +205,22 @@ buildattrs = ZF_ATTR="$(subst $(space),;,$(ATTR_LIST))"
 $(call target_variants,$(UT_NONSCRIPT_LISTS)):
 	@echo "Test target: $@"
 	sudo env $(UT_ENV) $(ENV) $(call buildattrs) \
+		UT_OUTPUT=$(UT_OUTPUT) TEST_TIME_OUT=$(TEST_TIME_OUT) TEST_TARGET="$@" \
 		timeout $(HARNESS_TIME_OUT) \
 		prove --exec \
-		"timeout $(TEST_TIME_OUT) $(NETNS_SCRIPT) $(VALGRIND_FLAGS)" \
+		"$(NETNS_SCRIPT)" \
 		$(PROVE_FLAGS) \
-		$^ \
-		$(PROVE_REDIRECT)
+		$^
 
 $(call target_variants,$(UT_SCRIPT_LISTS)):
 	@echo "Test target: $@"
 	sudo env $(UT_ENV) $(ENV) EXTRA_$(call buildattrs) \
+		UT_OUTPUT=$(UT_OUTPUT) TEST_TIME_OUT=$(TEST_TIME_OUT) \
 		timeout $(HARNESS_TIME_OUT) \
 		prove --exec \
-		"timeout $(TEST_TIME_OUT) $(NETNS_SCRIPT) $(VALGRIND_FLAGS)" \
+		"$(NETNS_SCRIPT)" \
 		$(PROVE_FLAGS) \
-		$^ \
-		$(PROVE_REDIRECT)
+		$^
 
 
 # The targets need to run sequentieally as each uses huge pages and spins on CPUs
@@ -255,13 +232,14 @@ $(call target_variants,$(UT_SCRIPT_LISTS)):
 # see we only use testdelegated_smallmtu
 test: testloop \
       testloop2_rx-x3 testloop2_x3 \
-      testloop_vlan testloop_txvi testmisc \
+      testloop_vlan testloop_txvi \
 			testb2bsb \
       testdelegated_smallmtu \
       testb2b testalts testalts_vlan testalts_txvi testpacketdrill
 
 test_jenkins: testjenkins \
               testscript_x3 \
+              testmisc \
               testscript
 
 


### PR DESCRIPTION
This commit makes a few minor changes to the tests:
- allow the Jenkins tests to fail and continue with the rest of the pipeline;
- run through all tests in GitHub actions, delaying failure to the end;
- log failed tests to the perform_build GitHub action stage summary;
- move the `testmisc` target to Jenkins for now, until it is fixed;
- flush stdout in assertions to avoid `SIGABRT` losing test output;
- switch to using the public onload repository for GitHub actions;
- improve skipping packetdrill tests for GitHub actions; and
- remove unused valgrind test wrappers.

### Testing Done
- GitHub actions run [with a failure](https://github.com/jfeather-amd/tcpdirect/actions/runs/8802425878) (before moving testmisc to Jenkins), scroll down on the linked page for the failure summary
- Passing GitHub action tick on this commit ([see here for the full run](https://github.com/jfeather-amd/tcpdirect/actions/runs/8803892680))
- Jenkins pipeline run, check my personal pipeline or message me for this

Note that the runs skip `packetdrill` because I didn't set up the necessary keys.