### PR TITLE
cleanup: use apt-get rather than apt in github actions

### DIFF
--- a/.github/workflows/perform_build.yml
+++ b/.github/workflows/perform_build.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Install yq
         run: |
-           sudo apt update
-           sudo apt install python3 python3-pip jq
+           sudo apt-get update
+           sudo apt-get install -y python3 python3-pip jq
            pip3 install yq
 
       - name: Extract TCPDirect branch name


### PR DESCRIPTION
Problem: 

https://github.com/Xilinx-CNS/tcpdirect/actions/runs/8814928979/job/24195841663

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

