### PR TITLE
Ensure zft_handle laddr is initialized on reuse

### DIFF
--- a/src/lib/zf/tcp.c
+++ b/src/lib/zf/tcp.c
@@ -64,6 +64,7 @@ static int __zft_handle_free(zf_stack* stack, zf_tcp* tcp)
 
   zf_stack_tcp_to_res(stack, tcp, &rx_res);
   zfrr_release_port(stack, rx_res);
+  memset(&tcp->laddr, 0, sizeof(tcp->laddr));
 
   if( tcp->eof_pkt != PKT_INVALID ) {
     zf_pool_free_pkt(&stack->pool, tcp->eof_pkt);

--- a/src/lib/zf/zf_tcp.c
+++ b/src/lib/zf/zf_tcp.c
@@ -23,6 +23,7 @@ static void zf_tcp_free(struct zf_stack* stack, struct zf_tcp* tcp)
   /* In case zocket was never connected but bound we need to free port
    * the same applies to zft_handle */
   zfrr_release_port(stack, rx_res);
+  memset(&tcp->laddr, 0, sizeof(tcp->laddr));
 
   if( tcp->eof_pkt != PKT_INVALID ) {
     zf_pool_free_pkt(&stack->pool, tcp->eof_pkt);

--- a/src/tests/zf_unit/zfzockfree.c
+++ b/src/tests/zf_unit/zfzockfree.c
@@ -128,9 +128,16 @@ static int create_zocket(struct zf_stack* stack, struct zf_attr* attr,
                          struct zft** tcp_out)
 {
   struct zft_handle* tcp_handle;
+  struct sockaddr_in laddr;
+  socklen_t len = sizeof(laddr);
+
   int rc = zft_alloc(stack, attr, &tcp_handle);
   if( rc < 0 )
     return rc;
+
+  zft_handle_getname(tcp_handle, (struct sockaddr *)&laddr, &len);
+  if( laddr.sin_port != 0 )
+    return -EBUSY;
 
   /* Do a loopback connect.  There's nothing listening, but we don't care: we
    * just want to install the filters. */
@@ -173,10 +180,16 @@ static int create_zocket(struct zf_stack* stack, struct zf_attr* attr,
 {
   (void) local_port_he;
   (void) remote_port_he;
+  struct sockaddr_in laddr;
+  socklen_t len = sizeof(laddr);
 
   int rc = zft_alloc(stack, attr, tcp_handle_out);
   if( rc < 0 )
     return rc;
+
+  zft_handle_getname(*tcp_handle_out, (struct sockaddr *)&laddr, &len);
+  if( laddr.sin_port != 0 )
+    return -EBUSY;
 
   return 0;
 }


### PR DESCRIPTION
Previously when a zft_handle was re-used after being free'd the laddr was not reinitialized.

First commit modifies zfzockfree test to demonstrate failure.
Second commit is proposed fix.

Failing test: [on_15816_test_fail.txt](https://github.com/Xilinx-CNS/tcpdirect/files/15433813/on_15816_test_fail.txt)
See
```
ok 449 - Freed TCP zocket 61
ok 450 - Freed TCP zocket 62
ok 451 - Freed TCP zocket 63
not ok 452 - Reallocated TCP zocket 0
#   Failed test 'Reallocated TCP zocket 0'
#   at src/tests/zf_unit//zfzockfree.c line 246.
#     -16
#         ==
#     0
```

and

```
ok 578 - Freed TCP zocket 62 again
ok 579 - Freed TCP zocket 63 again
Bail out!  Failed to allocate TCP handle 0 (rc = -16)
```

Passing test: [Uploading on_15816_test_pass.txt…]()
