### PR TITLE
ON-15689: use public accessor macros to read ef_vi tx ts data

### DIFF
--- a/src/include/zf_internal/tx_reports.h
+++ b/src/include/zf_internal/tx_reports.h
@@ -224,10 +224,16 @@ complete(struct queue* q, unsigned z, bool tcp, ef_event* ev)
   zf_assert(node->zock == zock_id(z, tcp));
   zock->pending = node->zock_next;
 
-  node->report.timestamp = {ev->tx_timestamp.ts_sec, ev->tx_timestamp.ts_nsec};
+  node->report.timestamp = {
+    .tv_sec  = EF_EVENT_TX_WITH_TIMESTAMP_SEC(*ev),
+    .tv_nsec = EF_EVENT_TX_WITH_TIMESTAMP_NSEC(*ev),
+  };
+
+  /* While ef_vi and TCPDirect have the same sync flags layout they can be
+   * copied without translation. */
   static_assert(EF_VI_SYNC_FLAG_CLOCK_SET == ZF_PKT_REPORT_CLOCK_SET);
   static_assert(EF_VI_SYNC_FLAG_CLOCK_IN_SYNC == ZF_PKT_REPORT_IN_SYNC);
-  node->report.flags |= (ev->tx_timestamp.ts_nsec & 3);
+  node->report.flags |= EF_EVENT_TX_WITH_TIMESTAMP_SYNC_FLAGS(*ev);
 }
 
 

--- a/src/tests/zf_unit/zftimestamping.c
+++ b/src/tests/zf_unit/zftimestamping.c
@@ -83,6 +83,7 @@ static void tx_report_batch(struct zf_tx_reports::queue* reports, int capacity,
         ev.tx_timestamp.type = EF_EVENT_TYPE_TX_WITH_TIMESTAMP;
         ev.tx_timestamp.ts_sec = r.timestamp.tv_sec;
         ev.tx_timestamp.ts_nsec = r.timestamp.tv_nsec;
+        ev.tx_timestamp.ts_flags = 0;
         zf_tx_reports::complete(reports, z/2, z%2, &ev);
       }
     }


### PR DESCRIPTION
Fixes problem whereby TCPDirect treated the bottom two bits of the timestamp nanosecond part as sync flags when these have now moved to a separate field in the event structure.