### PR TITLE
ON-15817: Fix flex array declaration macro in zf_emu

### DIFF
--- a/src/include/zf_internal/private/zf_emu.h
+++ b/src/include/zf_internal/private/zf_emu.h
@@ -4,6 +4,17 @@
 #define __ZF_INTERNAL_ZF_EMU_H__
 
 #include <cplane/mib.h>
+
+#ifdef __cplusplus
+/* Needed because in C++ an empty struct has a non-zero size. Additionally, a
+ * zero-length array is used instead of a standard flexible array member so that
+ * it can be used in the middle of a struct without gcc complaining. */
+#undef __DECLARE_FLEX_ARRAY
+#define __DECLARE_FLEX_ARRAY(TYPE, NAME)	\
+	struct { \
+		TYPE NAME[0]; \
+	}
+#endif
 #include <etherfabric/internal/efct_uk_api.h>
 
 /* These interface names are used for the default configuration of the "back-


### PR DESCRIPTION
The __DECLARE_FLEX_ARRAY macro which we now use in onload, results in a build failure for zf_emu as gcc will complain that a flex array is not the last element in a struct. Additionally, since zf_emu is technically C++ and not C an empty struct has a non-zero size. This commit addresses both of these issues by redefining the __DECLARE_FLEX_ARRAY macro in zf_emu so that the flex array is now just zero-length and removes the empty struct declaration.

## Testing done
Ran `make test` and unit tests passed
Also ran `zfsink`/`zfsend` as a sanity test which ran fine.