### PR TITLE
ON-15817: Cleanup: Fix missing macro definition

### DIFF
--- a/src/lib/zf/private/zf_emu_superbuf.h
+++ b/src/lib/zf/private/zf_emu_superbuf.h
@@ -16,6 +16,8 @@
 /* prevent ci/driver/ci_efct.h and ci_aux.h from getting included */
 #define CI_DRIVER_CI_EFCT_H
 
+#include <zf_internal/private/zf_emu.h>
+
 #include <ci/tools/sysdep.h>
 #include <ci/tools/debug.h>
 #include <ci/tools/log.h>


### PR DESCRIPTION
On older distros __DECLARE_FLEX_ARRAY macro is not defined and so builds fail. Fix this by including the definition from zf_emu.h into zf_emu_superbuf.h

## Testing done

### Jenkins
Jenkins pipeline passes (don't know if I can post links here or not), but some tests are a bit flaky.

### Manual
Also ran unit tests on my DUT with `make test`. There were some failures, but the same tests failed with old versions of onload+zf without my recent fixes, so I don't think it is a regression (potentially just a setup issue).

New versions:
zf: 2b2303850e664594db4a03a89cd6ecd8b61c2018
onload: Xilinx-CNS/onload_internal@8e9a3295b45432efb9b7773a2e6a2e14074bc136

"Old" versions:
zf: 38fc592dc1bd76be474a373003a44e60ab29624e
onload: Xilinx-CNS/onload_internal@75fa622f516a60d9600bf14956125b6c8956730d

Failing tests:
* `zfstackdump`
* `zf_tcp_sanity.sh` (fails in both X3 and non-X3 mode with a timeout - If I run it manually it does work it just takes a while)