### PR TITLE
ON-15038: View zf attibutes from zf_stackdump

### DIFF
--- a/src/include/zf_internal/private/zf_stack_def.h
+++ b/src/include/zf_internal/private/zf_stack_def.h
@@ -260,6 +260,29 @@ struct zf_stack_impl {
   int tcp_retries;
   int arp_reply_timeout;
 
+  /*adding all the zf attributes*/
+  int sti_ctpio;
+  char sti_ctpio_mode[8];  
+  int sti_alt_buf_size;
+  int sti_alt_count;
+  int sti_rx_ring_max;
+  int sti_rx_ring_refill_batch_size;
+  int sti_rx_timestamping;
+  int sti_tcp_alt_ack_rewind;
+  int sti_tcp_delayed_ack;
+  int sti_tcp_finwait_ms;
+  int sti_tcp_timewait_ms;
+  int sti_tcp_wait_for_time_wait; 
+  int sti_tx_ring_max;
+  int sti_tx_timestamping;
+  int sti_ctpio_max_frame_len;
+  int sti_force_separate_tx_vi;
+  int sti_pio;
+  int sti_reactor_spin_count;
+  int sti_rx_ring_refill_interval;
+  int sti_udp_ttl;
+  uint64_t sti_log_level;
+  
   int n_alts; /* Number of alternatives actually allocated to this VI */
   struct zf_alt alt[zf_stack::MAX_ALTERNATIVES]; /* indexed by ef_vi ID */
   struct zf_alt_buffer_model alt_buf_model;

--- a/src/include/zf_internal/zf_stackdump.h
+++ b/src/include/zf_internal/zf_stackdump.h
@@ -16,6 +16,9 @@ zf_stack_dump(struct zf_stack* stack);
 ZF_LIBENTRY ZF_COLD void
 zf_stack_dump_summary(struct zf_stack* stack);
 
+ZF_LIBENTRY ZF_COLD void
+zf_stack_dump_attr(struct zf_stack* stack);
+
 ZF_LIBENTRY ZF_COLD int
 zf_get_all_stack_shm_ids(int onload_dh, int* shm_ids, size_t count);
 

--- a/src/lib/zf/doxygen/040_using.dox
+++ b/src/lib/zf/doxygen/040_using.dox
@@ -860,6 +860,7 @@ zf_stackdump [command [stack_ids...]]
 Commands:
   list       List stack(s)
   dump       Show state of stack(s)
+  attr       Show attributes of stack(s)
 
 The default command is 'list'.  Commands iterate over all
 stacks if no stacks are specified on the command line.
@@ -869,22 +870,51 @@ enp4s0f0/0f0         id=10    pid=8845
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # zf_stackdump dump
 ============================================================
-name=enp4s0f0/0f0
+onload version=95264a9bfe 2024-06-13 onload-8.1
+tcpdirect version=8.1.3 onload-8.1 tcpdirect-8.1 0e8b1e3 2024-07-08
+name=ens4f0/112 interface=ens4f0 vlan_id=65535
   pool: pkt_bufs_n=17536 free=17025
-  config: tcp_timewait_ticks=666 tcp_finwait_ticks=666
+  config: tcp_timewait_ticks=666 tcp_finwait_ticks=666 ctpio_threshold=-1
   config: tcp_initial_cwnd=0 ms_per_tcp_tick=90
   alts: n_alts=0
-  stats: ring_refill_nomem=0 discard_csum_bad=0 discard_mcast_mismatch=0
+  stats: ring_refill_nomem=0 cplane_alien_ifindex=0
+         tcp_retransmits=0
+  discards: discard_csum_bad=0 discard_mcast_mismatch=0
          discard_crc_bad=0 discard_trunc=0 discard_rights=0
          discard_ev_error=0 discard_other=0 discard_inner_csum_bad=0
-         cplane_alien_ifindex=0
-nic0: vi=240 flags=0 intf=enp4s0f0 index=6 hw=1A1
-  txq: pio_buf_size=2048
+         non_tcpudp=0
+  hwport_to_nicno: [0,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,]
+nic0: vi=274 vi_flags=1000000 nic_flags=6 intf=ens4f0 index=13 hw=1C1
+  txq: pio_buf_size=4096 added=30286 removed=30286
 ============================================================
-UDP RX enp4s0f0/0f0:0
-  filter: lcl=172.16.130.252:8012 rmt=0.0.0.0:0
-  rx: unread=1 begin=0 process=0 end=1
-  udp rx: release_n=1 q_drops=0
+UDP TX ens4f0/112:0 lcl=192.168.131.36:9001 rmt=192.168.131.35:9001 ttl=64
+  path: dst=192.168.131.35 src=192.168.131.36 nic=0
+   L2: 14: 00 0a 35 0e cf a0 00 0f 53 64 50 50 08 00
+   L3: 20: 45 00 00 28 00 00 40 00 40 11 b3 2c c0 a8 83 24 c0 a8 83 23
+   L4:  8: 23 29 23 29 00 14 bf b8
+------------------------------------------------------------
+---------------------attributes-------------------------------
+tx_ring_max=512
+rx_ring_max=512
+tx_timestamping=0
+rx_timestamping=0
+ctpio=1
+ctpio_mode=sf-np
+pio=3
+reactor_spin_count=128
+tcp_timewait_ms=60000
+alt_buf_size=40960
+alt_count=0
+rx_ring_refill_batch_size=16
+tcp_alt_ack_rewind=65536
+tcp_delayed_ack=1
+tcp_finwait_ms=60000
+tcp_wait_for_time_wait=0
+ctpio_max_frame_len=-1
+force_separate_tx_vi=0
+rx_ring_refill_interval=1
+udp_ttl=64
+log_level=11111111
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 \subsection stack_stackdump stackdump output: stack
@@ -941,6 +971,7 @@ UDP RX enp4s0f0/0f0:0
 | -       | rmt                | remote_ip:port.
 | path    | dst                | destination server.
 | path    | src                | source server.
+| -       | ttl                | udp time to live value.
 
 \subsection tcp_stackdump stackdump output: TCP TX/RX
 
@@ -996,5 +1027,57 @@ UDP RX enp4s0f0/0f0:0
 | stats   | msg_more_send_delayed  | num of times there was no send because of MSG_MORE flag.
 | stats   | send_nomem             | num of times there were no free packet buffers to perform a send.
 | stats   | retransmits            | total num of tcp retransmits that have occurred.
+
+\subsection stackdump attr output:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# zf_stackdump attr
+============================================================
+ens4f0/112 id=1     pid=163603
+---------------------attributes-------------------------------
+tx_ring_max=512
+rx_ring_max=512
+tx_timestamping=0
+rx_timestamping=0
+ctpio=1
+ctpio_mode=sf-np
+pio=3
+reactor_spin_count=128
+tcp_timewait_ms=60000
+alt_buf_size=40960
+alt_count=0
+rx_ring_refill_batch_size=16
+tcp_alt_ack_rewind=65536
+tcp_delayed_ack=1
+tcp_finwait_ms=60000
+tcp_wait_for_time_wait=0
+ctpio_max_frame_len=-1
+force_separate_tx_vi=0
+rx_ring_refill_interval=1
+udp_ttl=64
+log_level=11111111
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+| Title  | Parameter                  | Description
+| :------| :----------------          | :------------------------------------------------
+| tx     |  tx_ring size              | size of the TX descriptor ring
+| rx     |  rx_ring size              | size of the RX descriptor ring
+| tx     |  tx_timestamping           | transmit timestamping
+| rx     |  rx_timestamping           | timestamps to received packets
+| tx     |  ctpio                     | Enable/Disable CTPIO.
+| tx     |  ctpio_mode                | Set the CTPIO mode to use
+| tx     |  pio                       | Enable/Disable PIO buffers
+| config |  reactor_spin_count        | number of iterations of the event processing loop zf_reactor_perform() will make (in the absence of any events) before returning.
+| tx     |  tcp_timewait_ms           | Length of TCP TIME-WAIT timer in ms.
+| tcp    |  alt_buf_size              | Amount of NIC-side buffer space to allocate for use with TCP alternatives on this VI.
+| tx     |  alt_count                 | Number of TCP alternatives to allocate on this VI
+| tx     |  rx_ring_refill_batch_size | Sets the number of packet buffers rx ring is refilled with on each zf_reactor_perform() call
+| tcp    |  tcp_alt_ack_rewind        | The maximum number of bytes by which outgoing ACKs will be allowed to go backwards when sending an alternative queue.
+| tcp    |  tcp_delayed_ack           | Enable TCP delayed ACK ("on" by default).
+| tcp    |  tcp_finwait_ms            | Length of TCP FIN-WAIT-2 timer in ms, 0 - disabled
+| tcp    |  tcp_wait_for_time_wait    | Do not consider a stack to be quiescent if there are any TCP zockets in the TIME_WAIT state
+| tx     |  ctpio_max_frame_len       | Sets the maximum frame length for the CTPIO low-latency transmit 
+| tx     |  force_separate_tx_vi      | Force seting up separate vi with dedicated evq for tx.
+| rx     |  rx_ring_refill_interval   | Sets the frequency of rx buffer ring refilling during inner zf_reactor_perform() loop
+| tx     |  udp_ttl                   | to control TTL on sent UDP packets
+| config |  log_level                 | Bitmask to enable different log message levels for each logging component.
 
 */

--- a/src/lib/zf/private/stack_alloc.c
+++ b/src/lib/zf/private/stack_alloc.c
@@ -841,6 +841,27 @@ int zf_stack_alloc(struct zf_attr* attr, struct zf_stack** stack_out)
 
   st->encap_type = if_cplane_info.encap.type;
   sti->sti_ifindex = ifindex;
+  sti->sti_ctpio = attr->ctpio;
+  sti->sti_tx_ring_max = attr->tx_ring_max;
+  sti->sti_alt_buf_size = attr->alt_buf_size;
+  sti->sti_alt_count = attr->alt_count;
+  sti->sti_rx_ring_max = attr->rx_ring_max;
+  sti->sti_rx_ring_refill_batch_size = attr->rx_ring_refill_batch_size;
+  sti->sti_rx_timestamping = attr->rx_timestamping;
+  sti->sti_tcp_alt_ack_rewind = attr->tcp_alt_ack_rewind;
+  sti->sti_tcp_delayed_ack = attr->tcp_delayed_ack;
+  sti->sti_tcp_finwait_ms = attr->tcp_finwait_ms;
+  sti->sti_tcp_timewait_ms = attr->tcp_timewait_ms;
+  sti->sti_tcp_wait_for_time_wait = attr->tcp_wait_for_time_wait; 
+  sti->sti_tx_timestamping = attr->tx_timestamping;
+  sti->sti_ctpio_max_frame_len = attr->ctpio_max_frame_len;
+  sti->sti_force_separate_tx_vi = attr->force_separate_tx_vi;
+  sti->sti_pio = attr->pio;
+  sti->sti_reactor_spin_count = attr->reactor_spin_count;
+  sti->sti_rx_ring_refill_interval = attr->rx_ring_refill_interval;
+  sti->sti_udp_ttl = attr->udp_ttl;
+  sti->sti_log_level = attr->log_level;
+  strncpy(sti->sti_ctpio_mode, attr->ctpio_mode, 8);
   if( st->encap_type & CICP_LLAP_TYPE_VLAN )
     sti->sti_vlan_id = if_cplane_info.encap.vlan_id;
   else
@@ -941,13 +962,11 @@ int zf_stack_alloc(struct zf_attr* attr, struct zf_stack** stack_out)
     if( rc < 0 )
       goto fail4;
   }
-
   if( attr->name )
     strncpy(st->st_name, attr->name, sizeof(st->st_name));
   else
     sprintf(st->st_name, "%s/%03x", attr->interface, st->nic[0].vi.vi_i);
   strncpy(sti->sti_if_name, attr->interface, IF_NAMESIZE - 1);
-
   *stack_out = st;
   return 0;
 

--- a/src/lib/zf/udp_tx.c
+++ b/src/lib/zf/udp_tx.c
@@ -125,10 +125,10 @@ void zfut_dump(SkewPointer<zf_stack> stack, SkewPointer<zf_udp_tx> udp_tx)
   ZF_INET_NTOP_DECLARE_BUF(rbuf);
 
   zf_dump("UDP TX %." ZF_STRINGIFY(ZF_STACK_NAME_SIZE)
-          "s:%u lcl=%s:%d rmt=%s:%u\n",
+          "s:%u lcl=%s:%d rmt=%s:%u ttl=%d\n",
           stack->st_name, UDP_TX_ID(stack, udp_tx),
           ZF_INET_NTOP_CALL(ip->saddr, lbuf), ntohs(udp->source),
-          ZF_INET_NTOP_CALL(ip->daddr, rbuf), ntohs(udp->dest));
+          ZF_INET_NTOP_CALL(ip->daddr, rbuf), ntohs(udp->dest), ip->ttl);
   zf_waitable_dump(udp_tx.propagate_skew(&udp_tx->w));
   zf_tx_dump(&udp_tx->tx, IPPROTO_UDP);
 }

--- a/src/lib/zf/zf_stackdump.c
+++ b/src/lib/zf/zf_stackdump.c
@@ -26,6 +26,40 @@ static void dump_zockets(SkewPointer<zf_stack> stack, Zocket* zockets,
   }
 }
 
+void dump_attributes(SkewPointer<zf_stack_impl> stimpl)
+{
+  zf_dump("---------------------attributes-------------------------------\n");
+  
+  if(stimpl->sti_tx_ring_max == -1)
+    zf_dump("tx_ring_max=512\n");
+  else
+    zf_dump("tx_ring_max=%d\n", stimpl->sti_tx_ring_max);
+  
+  if(stimpl->sti_rx_ring_max == -1)
+    zf_dump("rx_ring_max=512\n");
+  else
+    zf_dump("rx_ring_max=%d\n", stimpl->sti_rx_ring_max);
+
+  zf_dump("tx_timestamping=%d\n", stimpl->sti_tx_timestamping);  
+  zf_dump("rx_timestamping=%d\n", stimpl->sti_rx_timestamping);  
+  zf_dump("ctpio=%d\n", stimpl->sti_ctpio);
+  zf_dump("ctpio_mode=%s\n", stimpl->sti_ctpio_mode);
+  zf_dump("pio=%d\n", stimpl->sti_pio);
+  zf_dump("reactor_spin_count=%d\n", stimpl->sti_reactor_spin_count);
+  zf_dump("tcp_timewait_ms=%d\n", stimpl->sti_tcp_timewait_ms);  
+  zf_dump("alt_buf_size=%d\n", stimpl->sti_alt_buf_size);  
+  zf_dump("alt_count=%d\n", stimpl->sti_alt_count);  
+  zf_dump("rx_ring_refill_batch_size=%d\n", stimpl->sti_rx_ring_refill_batch_size);
+  zf_dump("tcp_alt_ack_rewind=%d\n", stimpl->sti_tcp_alt_ack_rewind);  
+  zf_dump("tcp_delayed_ack=%d\n", stimpl->sti_tcp_delayed_ack);  
+  zf_dump("tcp_finwait_ms=%d\n", stimpl->sti_tcp_finwait_ms);  
+  zf_dump("tcp_wait_for_time_wait=%d\n", stimpl->sti_tcp_wait_for_time_wait);  
+  zf_dump("ctpio_max_frame_len=%d\n", stimpl->sti_ctpio_max_frame_len);
+  zf_dump("force_separate_tx_vi=%d\n", stimpl->sti_force_separate_tx_vi);
+  zf_dump("rx_ring_refill_interval=%d\n", stimpl->sti_rx_ring_refill_interval);
+  zf_dump("udp_ttl=%d\n", stimpl->sti_udp_ttl); 
+  zf_dump("log_level=%X\n", stimpl->sti_log_level); 
+}
 
 void dump_zockets(SkewPointer<zf_stack_impl> sti)
 {
@@ -147,9 +181,22 @@ void zf_stack_dump(struct zf_stack* stack)
   dump_stack(stimpl);
   zf_dump("============================================================\n");
   dump_zockets(stimpl);
+  dump_attributes(stimpl);
 
   dump_alts(stimpl);
 };
+
+void zf_stack_dump_attr(struct zf_stack* stack)
+{
+    auto stimpl = SkewPointer<zf_stack_impl>(ZF_CONTAINER(struct zf_stack_impl,
+                                                        st, stack));
+
+  zf_dump("============================================================\n");
+  zf_stack_dump_summary(stack);
+  dump_attributes(stimpl);
+  
+  dump_alts(stimpl);
+}
 
 
 void zf_stack_dump_summary(struct zf_stack* stack)

--- a/src/tools/zf/zf_stackdump.c
+++ b/src/tools/zf/zf_stackdump.c
@@ -17,6 +17,7 @@ static void usage(int rc)
   zf_log(NULL, "  help       Print this usage information\n");
   zf_log(NULL, "  list       List stack(s)\n");
   zf_log(NULL, "  dump       Show state of stack(s)\n");
+  zf_log(NULL, "  attr       Show attributes of stack(s)\n");
   zf_log(NULL, "  version    Print tcpdirect version information\n");
   zf_log(NULL, "\n");
   zf_log(NULL, "The default command is 'list'.  Commands iterate over all\n");
@@ -56,6 +57,8 @@ int main(int argc, char *argv[])
       version();
     else if( strcmp(argv[0], "help") == 0 )
       usage(0);
+    else if( strcmp(argv[0], "attr") == 0 )
+      cmd = zf_stack_dump_attr;
     else
       usage(1);
 


### PR DESCRIPTION
Added to view attributes in the output of the `zf_stackdump dump`
```
dellr250u:~/devel/fgit/test-onload-git/tcpdirect/build/gnu_x86_64/bin$ ./zf_stackdump dump
============================================================
onload version=27eb4307c8 2023-11-15 onload-8.1.2
tcpdirect version=8.1.3 onload-8.1 tcpdirect-8.1 0c08e35 2024-05-03 v8_1
name=ens1f0/10a interface=ens1f0 vlan_id=65535
  pool: pkt_bufs_n=21632 free=17537
  config: tcp_timewait_ticks=666 tcp_finwait_ticks=666 ctpio_threshold=64
  config: tcp_initial_cwnd=0 ms_per_tcp_tick=90
  alts: n_alts=0
  stats: ring_refill_nomem=0 cplane_alien_ifindex=0
         tcp_retransmits=0
  discards: discard_csum_bad=0 discard_mcast_mismatch=0
         discard_crc_bad=0 discard_trunc=0 discard_rights=0
         discard_ev_error=0 discard_other=0 discard_inner_csum_bad=0
         non_tcpudp=0
  hwport_to_nicno: [0,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,]
nic0: vi=266 vi_flags=1000000 nic_flags=1 intf=ens1f0 index=10 hw=1C1
  txq: pio_buf_size=4096 added=0 removed=0
============================================================
TCP LISTEN ens1f0/10a:0 lcl=192.168.138.232:9001
  acceptq: no
------------------------------------------------------------
---------------------attributes-------------------------------
tx_ring size= 1024
rx_ring size= 4096
tx_timestamping= 0
rx_timestamping= 0
ctpio= 1
ctpio_mode= ct
pio= 1
reactor_spin_count= 128
tcp_timewait_wait= 60000
alt_buf_size= 40960
alt_count= 0
rx_ring_refill_batch_size= 16
tcp_alt_ack_rewind= 65536
tcp_delayed_ack= 1
tcp_finwait_ms= 60000
tcp_wait_for_time_ms= 0
ctpio_max_frame_len= -1
force_separate_tx_vi= 0
rx_ring_refill_interval= 1
udp_ttl= 64
log_level= 286331153
============================================================
onload version=27eb4307c8 2023-11-15 onload-8.1.2
tcpdirect version=8.1.3 onload-8.1 tcpdirect-8.1 0c08e35 2024-05-03 v8_1
name=ens1f1/10a interface=ens1f1 vlan_id=65535
  pool: pkt_bufs_n=17536 free=17025
  config: tcp_timewait_ticks=666 tcp_finwait_ticks=666 ctpio_threshold=-1
  config: tcp_initial_cwnd=0 ms_per_tcp_tick=90
  alts: n_alts=0
  stats: ring_refill_nomem=0 cplane_alien_ifindex=0
         tcp_retransmits=0
  discards: discard_csum_bad=0 discard_mcast_mismatch=0
         discard_crc_bad=0 discard_trunc=0 discard_rights=0
         discard_ev_error=0 discard_other=0 discard_inner_csum_bad=0
         non_tcpudp=0
  hwport_to_nicno: [-1,0,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,]
nic0: vi=266 vi_flags=1000000 nic_flags=1 intf=ens1f1 index=11 hw=1C1
  txq: pio_buf_size=4096 added=0 removed=0
============================================================
TCP LISTEN ens1f1/10a:0 lcl=192.168.130.232:9001
  acceptq: no
------------------------------------------------------------
---------------------attributes-------------------------------
tx_ring size= 512
rx_ring size= 512
tx_timestamping= 0
rx_timestamping= 0
ctpio= 1
ctpio_mode= sf-np
pio= 2
reactor_spin_count= 128
tcp_timewait_wait= 60000
alt_buf_size= 40960
alt_count= 0
rx_ring_refill_batch_size= 16
tcp_alt_ack_rewind= 65536
tcp_delayed_ack= 1
tcp_finwait_ms= 60000
tcp_wait_for_time_ms= 0
ctpio_max_frame_len= -1
force_separate_tx_vi= 0
rx_ring_refill_interval= 1
udp_ttl= 64
log_level= 286331153
```
Added option to view only attributes `zf_stackdump attr`
```
dellr250u:~/devel/fgit/test-onload-git/tcpdirect/build/gnu_x86_64/bin$ ./zf_stackdump attr
============================================================
ens1f1/10a id=14    pid=122818
---------------------attributes-------------------------------
tx_ring size= 512
rx_ring size= 512
tx_timestamping= 0
rx_timestamping= 0
ctpio= 1
ctpio_mode= sf-np
pio= 2
reactor_spin_count= 128
tcp_timewait_wait= 60000
alt_buf_size= 40960
alt_count= 0
rx_ring_refill_batch_size= 16
tcp_alt_ack_rewind= 65536
tcp_delayed_ack= 1
tcp_finwait_ms= 60000
tcp_wait_for_time_ms= 0
ctpio_max_frame_len= -1
force_separate_tx_vi= 0
rx_ring_refill_interval= 1
udp_ttl= 64
log_level= 286331153
```