### PR TITLE
ON-15163: Update to use generic warming functions

### DIFF
--- a/src/include/zf_internal/tx_warm.h
+++ b/src/include/zf_internal/tx_warm.h
@@ -8,7 +8,7 @@
 #include <zf_internal/tx_types.h>
 #include <zf_internal/zf_pool.h>
 extern "C" {
-#include <etherfabric/internal/internal.h>
+#include <etherfabric/ef_vi.h>
 }
 
 struct zf_tx_warm_state {

--- a/src/lib/zf/tx_warm.c
+++ b/src/lib/zf/tx_warm.c
@@ -14,22 +14,16 @@ int enable_tx_warm(struct zf_tx* tx, zf_tx_warm_state* state)
   ef_vi* vi = zf_stack_nic_tx_vi(st_nic);
   zf_assert_nflags(st->flags, ZF_STACK_FLAG_TRANSMIT_WARM_ENABLED);
   zf_log_stack_trace(st, "%s: TX warm enabled\n", __func__);
-  /* TODO better way to distuinguish X2 vs X3 style CTPIO */
-  if( vi->nic_type.arch == EF_VI_ARCH_EFCT ) {
-    efct_vi_start_transmit_warm(vi);
+  char* ctpio_warm_buf = NULL;
+  state->ctpio_warm_buf_id = PKT_INVALID;
+  if( vi->vi_flags & EF_VI_TX_CTPIO && vi->nic_type.arch != EF_VI_ARCH_EFCT ) {
+    int rc = zft_alloc_pkt(&st->pool, &state->ctpio_warm_buf_id);
+    if( rc < 0 )
+      return rc;
+    ctpio_warm_buf = PKT_BUF_BY_ID(&st->pool, state->ctpio_warm_buf_id);
   }
-  else {
-    char* ctpio_warm_buf = NULL;
-    state->ctpio_warm_buf_id = PKT_INVALID;
-    if( vi->vi_flags & EF_VI_TX_CTPIO ) {
-      int rc = zft_alloc_pkt(&st->pool, &state->ctpio_warm_buf_id);
-      if( rc < 0 )
-        return rc;
-      ctpio_warm_buf = PKT_BUF_BY_ID(&st->pool, state->ctpio_warm_buf_id);
-    }
-    ef_vi_start_transmit_warm(vi, &state->ef_vi_state[tx->path.nicno],
-                              ctpio_warm_buf);
-  }
+  ef_vi_start_transmit_warm(vi, &state->ef_vi_state[tx->path.nicno],
+                            ctpio_warm_buf);
   st->flags |= ZF_STACK_FLAG_TRANSMIT_WARM_ENABLED;
   return 0;
 }
@@ -42,15 +36,9 @@ void disable_tx_warm(struct zf_tx* tx, zf_tx_warm_state* state)
   ef_vi* vi = zf_stack_nic_tx_vi(st_nic);
   zf_assert_flags(st->flags, ZF_STACK_FLAG_TRANSMIT_WARM_ENABLED);
   zf_log_stack_trace(st, "%s: TX warm disabled\n", __func__);
-  /* TODO better way to distuinguish X2 vs X3 style CTPIO */
-  if( vi->nic_type.arch == EF_VI_ARCH_EFCT ) {
-    efct_vi_stop_transmit_warm(vi);
-  }
-  else {
-    ef_vi_stop_transmit_warm(vi, &state->ef_vi_state[tx->path.nicno]);
-    if( state->ctpio_warm_buf_id != PKT_INVALID )
-      zf_pool_free_pkt(&st->pool, state->ctpio_warm_buf_id);
-  }
+  ef_vi_stop_transmit_warm(vi, &state->ef_vi_state[tx->path.nicno]);
+  if( state->ctpio_warm_buf_id != PKT_INVALID )
+    zf_pool_free_pkt(&st->pool, state->ctpio_warm_buf_id);
   st->flags &= ~ZF_STACK_FLAG_TRANSMIT_WARM_ENABLED;
 }
 


### PR DESCRIPTION
Change has been made to deprecate the architecture specific and transmit method specific warming functions. Generic functions for enabling or disabling transmit warming functionality should be used instead.

This commit updates TCPDirect to use the generic ef_vi functions.

Testing was done with zftcppingpong_sleep

Below is perf trace showing new generic methods used on X3 for transmit warming.
![tcpdirect_warming](https://github.com/Xilinx-CNS/tcpdirect/assets/138598809/c69de028-865a-47e9-b9b6-7e898607c37e)

Test was also ran on X2.
