### PR TITLE
ON-15255: use ef_vi packet in timestamp calls

### DIFF
--- a/src/lib/zf/private/zf_emu.c
+++ b/src/lib/zf/private/zf_emu.c
@@ -1153,7 +1153,7 @@ static void emu_deliver_x3(emu_state* emu, emu_vi* evi,
 
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC, &ts);
-  uint64_t timestamp = (ts.tv_sec << 32) | (ts.tv_nsec << 2);
+  uint64_t timestamp = (ts.tv_sec << 32) | (ts.tv_nsec);
 
   uint64_t poisoned = 0;
   __builtin_memcpy((char*)&poisoned + 2, txbuf, 6);


### PR DESCRIPTION
Commit da134ec0d456 (ON-15255: use new unified ef_vi timestamping API, 2024-07-01) was an improper patch, and used to wrong packet reference; instead of referencing the ef_vi rxpkt it instead tried to reference the TCPDirect packet store. This change references the correct packet to correctly extract a timestamp.

This change also teaches zf_emu to expect sub-nanosecond resolution timestamps, rather than the previous clobbering of the lower-order bits in the nanoseconds field.

### Testing
zf_emu is happy running x3 tests again, although why they were always happy on github is a mystery to me.