### PR TITLE
ON-15875: add --name option to zf_mkdist

### DIFF
--- a/ci/test.groovy
+++ b/ci/test.groovy
@@ -206,7 +206,7 @@ nm.slack_notify() {
                     returnStdout: true)
       sh """#!/bin/bash
         export CC=${CC}
-        tcpdirect/scripts/zf_mkdist --version ${tcpdirect_version_long} ${onload_tarball}
+        tcpdirect/scripts/zf_mkdist --version ${tcpdirect_version_long} --name tcpdirect ${onload_tarball}
       """
       extractNotes("tcpdirect/scripts", "tcpdirect/build/tcpdirect-${tcpdirect_version_long}.tgz")
       dir('tcpdirect/build/') {

--- a/scripts/zf_mkdist
+++ b/scripts/zf_mkdist
@@ -33,6 +33,7 @@ usage() {
     echo "options:"
     echo "  --version <version>"
     echo "  --shim"
+    echo "  --name <tarball_prefix>"
     echo
     exit 1
 }
@@ -61,7 +62,7 @@ grab_artifacts_from_tmpdir() {
 
 make_release_package() {
     package_version="$1"
-    "${top_dir}"/scripts/zf_make_tarball --version "${package_version}"
+    "${top_dir}"/scripts/zf_make_tarball --version "${package_version}" --name "${name}"
 }
 
 
@@ -162,6 +163,7 @@ build_zf() {
 version=
 stripped=true
 shim=false
+name="zf"
 build_opts=""
 onload_tarball=
 tarball_count=0
@@ -171,6 +173,7 @@ while [ $# -gt 0 ]; do
         --version)  shift; version="$1";;
         --unstripped) stripped=false;;
         --shim) shim=true;;
+        --name) shift; name="$1";;
         -*)  usage;;
         *)  onload_tarball="$1"; tarball_count=$((tarball_count+1));;
     esac


### PR DESCRIPTION
This option is passed through to zf_make_tarball and is used as the start of the generated tarball name. Previously, zf_mkdist would specify this as "zf", but this was dropped in Commit 05f83369e204 ("ON-15875: use onload tarball in Jenkins pipeline") which meant the new default was "tcpdirect" to match the existing Jenkins pipeline. However, this broke other consumers of zf_mkdist that expected a tarball starting with "zf" to be generated. As such, this change both adds the option for this to be configured, to be used in the Jenkins pipeline, and reverts to the previous default name prefix "zf".

### Testing Done
Manually generated a tarball as below to verify new behaviour:
```
$ ./scripts/zf_mkdist ../onload.tgz
[ ... ]
Written zf-bb4df1d6ebc60ee0cad1372823cce0426f7f1321.tgz

$ ./scripts/zf_mkdist --name tcpdirect ../onload.tgz
[ ... ]
Written tcpdirect-bb4df1d6ebc60ee0cad1372823cce0426f7f1321.tgz
```

I have also tested that this works with our CI.