### PR TITLE
ON-15664: Generate SRPM with sources and not pre-built binaries

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -20,6 +20,24 @@ Execute the following command from the root of the repository:
 export ONLOAD_TREE={path to the checked out onload repository}
 make
 ```
+
+### Packaging
+Use the [`zf_make_official_srpm`](./scripts/zf_make_official_srpm) script to create an SRPM package:
+
+```bash
+scripts/zf_make_official_srpm --version ${version}
+```
+
+The `${version}` variable can be git hexsha such as `d42f94d5` or a semver string such as `9.0.0`.
+
+Execute the following command to create an RPM package from SRPM:
+
+```bash
+rpmbuild --define "onload_tarball ${onload}" --rebuild ~/rpmbuild/SRPMS/tcpdirect-${version}-1.src.rpm
+```
+
+Here, the `${onload}` variable points to an Onload tarball, and `${version}` is the same as for `zf_make_official_srpm`.
+
 ## How to run unit tests
 
 ### Dependencies

--- a/ci/test.groovy
+++ b/ci/test.groovy
@@ -221,9 +221,8 @@ nm.slack_notify() {
       "publish release rpm": {
         node("publish-rpm-parallel") {
           deleteDir()
-          unstash('tcpdirect-release-tarball')
           unstash('tcpdirect-src')
-          sh "tcpdirect/scripts/zf_make_official_srpm tcpdirect-${tcpdirect_version_long}.tgz --version ${tcpdirect_version_long}"
+          sh "tcpdirect/scripts/zf_make_official_srpm --version ${tcpdirect_version_long}"
           archiveArtifacts allowEmptyArchive: true, artifacts: '*.src.rpm', followSymlinks: false
           unstash('text_files')
           zip_and_archive_files(

--- a/scripts/tcpdirect_misc/tcpdirect.spec
+++ b/scripts/tcpdirect_misc/tcpdirect.spec
@@ -1,9 +1,16 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: (c) 2016-2023 Advanced Micro Devices, Inc.
 ######################################################################
+# RPM spec file for TCPDirect
+#
+# To build a source RPM:
+#   scripts/zf_make_official_srpm --version <version>
+#
+# To build a binary RPM from a source RPM:
+#   rpmbuild --define "onload_tarball <onload_tarball>" --rebuild ~/rpmbuild/SRPMS/tcpdirect-<version>-1.src.rpm
 
 %define _unpackaged_files_terminate_build 0
-pkgversion-DEFINITION
+%{!?pkgversion: %global pkgversion 9.0.0}
 
 Name:           tcpdirect
 Version:        %{pkgversion}
@@ -13,6 +20,8 @@ Summary:        TCPDirect
 License:        MIT AND BSD-3-Clause AND LGPL-3.0
 URL:            https://github.com/Xilinx-CNS/tcpdirect
 Source0:        tcpdirect-%{pkgversion}.tgz
+BuildRequires:  gcc make
+BuildRoot:      %{_builddir}/%{name}-root
 
 Vendor:         Advanced Micro Devices, Inc.
 
@@ -30,11 +39,13 @@ This package comprises the user space components of tcpdirect.
 [ "$RPM_BUILD_ROOT" != / ] && rm -rf "$RPM_BUILD_ROOT"
 mkdir -p $RPM_BUILD_ROOT
 
-
-
+%setup -n %{name}-%{pkgversion}
 
 %build
-tar -xzvf %{_sourcedir}/tcpdirect-%{pkgversion}.tgz -C $RPM_BUILD_ROOT
+scripts/zf_mkdist --version "%{pkgversion}" --name tcpdirect "%{?onload_tarball:%onload_tarball}"
+
+tar -xzvf build/tcpdirect-"%{pkgversion}".tgz -C "${RPM_BUILD_ROOT}"
+
 ls -la $RPM_BUILD_ROOT
 ls -la $RPM_BUILD_ROOT/tcpdirect-%{pkgversion}/scripts
 # $RPM_BUILD_ROOT/tcpdirect-%{pkgversion}/scripts/zf_install

--- a/scripts/zf_make_official_srpm
+++ b/scripts/zf_make_official_srpm
@@ -9,89 +9,88 @@ log()  { err "$me: $*"; }
 fail() { log "$*"; exit 1; }
 try()  { "$@" || fail "FAILED: $*"; }
 
+my_dir=$(cd "$(dirname "$0")" && /bin/pwd)
+top_dir=$(dirname "${my_dir}")
 
-usage_msg() {
-  err
-  err "usage:"
-  err "  $me <tcpdirect-tarball>"
-  err
-  err "options:"
-  err
-}
-
+tarball_files_from="
+versions.yaml
+Makefile
+Makefile.onload
+Makefile-top.inc
+doc
+src
+scripts/debian-templ
+scripts/tcpdirect_misc/tcpdirect-extract-notes
+scripts/zf_debug
+scripts/zf_install
+scripts/zf_make_official_deb
+scripts/zf_make_official_srpm
+scripts/zf_make_tarball
+scripts/zf_mkdist
+scripts/zf_uninstall
+"
 
 usage() {
-  usage_msg
+  echo
+  echo "usage:"
+  echo "  $(basename "$0") [options]"
+  echo
+  echo "options:"
+  echo "  --version <version>"
+  echo
   exit 1
 }
 
-
-logtry() {
-  log "$*"
-  try "$@"
-}
-
-
 cleanup() {
-  [ -d "$tmpd" ] && rm -rf "$tmpd"
+  echo "Deleting ${tmpdir}"
+  rm -rf "${tmpdir}"
 }
-
 
 ######################################################################
 # main()
+
 version=
-tarball=
 
 while [ $# -gt 0 ]; do
-    case "$1" in
-        --version)  shift; version="$1";;
-        -*)  usage;;
-        *)  tarball="$1";;
-    esac
-    shift
+  case "$1" in
+    --version)  shift; version="$1";;
+    *)  usage;;
+  esac
+  shift
 done
 
-if [ -z "$version" ]; then
+if [ -z "${version}" ]; then
     version=$(git rev-parse HEAD)
 fi
 
-# [ $# = 1 ] || usage
-# tarball="$1"
+tmpdir=$(mktemp -d "/tmp/${me}.XXXXXXXX")
+zf_prefix="tcpdirect-${version}"
+zf_spec="scripts/tcpdirect_misc/tcpdirect.spec"
+zf_tarball="${tmpdir}/${zf_prefix}.tar"
+zf_tgz="${tmpdir}/${zf_prefix}.tgz"
 
-tmpd=
 trap cleanup EXIT
-tmpd=$(mktemp -d /tmp/$me.XXXXXXXX)
 
-try [ -f "$tarball" ]
-tarballdir=$(cd "$(dirname "$tarball")" && /bin/pwd)
-tarballbase=$(basename "$tarball")
-tarball="$tarballdir/$tarballbase"
-try [ -f "$tarball" ]
+# Create a tarball in tmpdir.
+# shellcheck disable=SC2086
+try tar -c -C "${top_dir}" --transform "s,^,${zf_prefix}/,S" -f "${zf_tarball}" -- ${tarball_files_from}
 
-original_wd=$(/bin/pwd)
-try cd "$tmpd"
+# Patch and put the SPEC file in tmpdir.
+# shellcheck disable=SC2046
+mkdir -pv $(dirname "${tmpdir}/${zf_prefix}/${zf_spec}")
 
-# Edit the "Packager" line in the rpm spec file and rebuild tarball.
-try tar xf "$tarball"
-distd="$(basename "${tarball%.tgz}")"
-try [ -d "$distd" ]
-tab=$(echo -n -e "\t")
-try rm "$distd/scripts/zf_install" "$distd/scripts/zf_uninstall"
+try sed \
+  -E "s/^.*(%global pkgversion).*$/%define pkgversion ${version}/" "${top_dir}/${zf_spec}" \
+  > "${tmpdir}/${zf_prefix}/${zf_spec}"
 
-try sed -i \
- -e "s/pkgversion-DEFINITION/%define pkgversion $version/g" \
- "$distd/scripts/tcpdirect.spec"
+# Add the patched SPEC file in the tarball.
+try tar -v -C "${tmpdir}" --append -f "${zf_tarball}" -- "${zf_prefix}/${zf_spec}"
 
-tarball=$(basename "$tarball")
-try tar czf "$tarball" --owner=root --group=root "$distd"
+# Compress the tarball.
+try gzip -v "${zf_tarball}"
 
-# Build source rpm.
-try mkdir -p rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
-try rpmbuild --nodeps --define "_topdir $PWD/rpmbuild" -ts "$tarball"
-srpm=$(/bin/ls rpmbuild/SRPMS/*.rpm)
-srpmbase=$(basename "$srpm")
-destfile="$original_wd/$(echo "$srpmbase" | sed -e 's/\.el6//')"
-[ -f "$destfile" ] &&
-  fail "ERROR: '$destfile' already exists.  I will not overwrite."
-try cp "$srpm" "$destfile"
-echo "$destfile"
+# Rename the compressed file extension tar.gz -> tgz.
+try mv -v "${zf_tarball}.gz" "${zf_tgz}"
+
+# Create SRPM.
+try rpmbuild -ts "${zf_tgz}"

--- a/scripts/zf_mkdist
+++ b/scripts/zf_mkdist
@@ -97,7 +97,8 @@ build_and_copy_artifacts() {
     rm -rf "${build_dir}"/onload
     rm -rf "${build_dir}"/gnu*
     cd "${zf_tmpdir}"
-    make ${make_args}
+    # shellcheck disable=SC2086
+    make ${parallel} ${make_args}
     build_tree=$(ls -d "${build_dir}"/gnu*)
     copy_artifacts "${build_tree}" "${artifact_dir}" "${build_type}"
 }
@@ -165,6 +166,7 @@ stripped=true
 shim=false
 name="zf"
 build_opts=""
+parallel=-j$(nproc)
 onload_tarball=
 tarball_count=0
 


### PR DESCRIPTION
Put TCPDirect source files instead of pre-built binaries into the SRPM package generated by the `zf_make_official_srpm` script.

It is quite a crude PR because, for instance, it does not list the tarball files explicitly and can catch temporary text editor files into the tarball, but there are more series to come to address it.

TODO:
- [x] Fix CI (test.groovy): Pass (Amber, in a personal pipeline)