### PR TITLE
ON-15945: Build tcpdirect against system installed onload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,16 @@
 .DEFAULT_GOAL := all
 
 TOP := $(patsubst %/,%,$(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
-
+ifdef ONLOAD_TREE
 include Makefile.onload
+else
+  ifeq ($(ZF_DEVEL),1)
+    $(error ZF_DEVEL unsupported when building from installed onload)
+  endif
+  $(info Using installed onload libraries and headers)
+  CITOOLS_LIB := /usr/lib64/libcitools1.a
+  CIUL_LIB    := /usr/lib64/libciul1.a
+endif
 include Makefile-top.inc
 
 # Use Onload's build-tree structure, unless overridden.

--- a/Makefile.onload
+++ b/Makefile.onload
@@ -9,7 +9,7 @@ endif
 
 .PHONY: build_dir
 
-ONLOAD_SCRIPTS := $(ONLOAD_TREE)/scripts
+ONLOAD_SCRIPTS := $(shell realpath $(ONLOAD_TREE))/scripts
 export PATH := $(ONLOAD_SCRIPTS):$(PATH)
 
 

--- a/src/lib/zf/Makefile.inc
+++ b/src/lib/zf/Makefile.inc
@@ -50,23 +50,25 @@ ZF_GIT_BRANCH_INFO  := $(shell git symbolic-ref -q --short HEAD)
 public_objects: $(PUBLIC_OBJS)
 .PHONY: public_objects
 
+ifdef ONLOAD_TREE
+  ONLOAD_CFLAGS  := -I$(ONLOAD_TREE)/src/include \
+                    -I$(ONLOAD_UL_BUILD_DIR)/include \
+                    '-DONLOAD_VERSION_HDR="onload_version.h"'
+else
+  ONLOAD_CFLAGS  := '-DONLOAD_VERSION_HDR=<onload/onload_version.h>'
+endif
 # ZF sources are C files that are built as C++ using the cc command.  The
 # reasons being:
 #  * files can stay .c
 #  * gcc does not enable exceptions nor link with stdcpp library (as opposed to
 #    C++).
-# XXX: ZF has no business requiring TRANSPORT_CONFIG_OPT_HDR.  We're pulling
-# in too much from Onload in order to get oo_resource_mmap() and the other
-# wrappers around /dev/onload ops.
 $(LIB_OBJS): ZF_CFLAGS_COMPONENT := \
   $(ZF_CFLAGS_COMMON) \
   $(ZF_CXXFLAGS_COMMON) \
   -fvisibility=hidden \
   $(ONLOAD_VERSION_CFLAGS) \
-  -I$(ONLOAD_TREE)/src/include \
-  -I$(ONLOAD_UL_BUILD_DIR)/include \
+  $(ONLOAD_CFLAGS) \
   -fPIC \
-  '-DTRANSPORT_CONFIG_OPT_HDR=<ci/internal/transport_config_opt_extra.h>' \
   '-DZF_VERSION="$(ZF_SEMANTIC_VERSION) \
   $(ZF_GIT_VERSION_INFO) \
   $(ZF_GIT_BRANCH_INFO)"'

--- a/src/lib/zf/shim/Makefile.inc
+++ b/src/lib/zf/shim/Makefile.inc
@@ -8,22 +8,22 @@ SOCKET_SHIM_SRCS := socket_shim.c socket_fd.c socket_common.c \
 SOCKET_SHIM_OBJS := $(SOCKET_SHIM_SRCS:%.c=$(OBJ_CURRENT)/%.o)
 SOCKET_SHIM_SO   := $(LIB_ROOT)/libzf_sockets.so
 
+ifdef ONLOAD_TREE
+  ONLOAD_CFLAGS  := -I$(ONLOAD_TREE)/src/include \
+                    -I$(ONLOAD_UL_BUILD_DIR)/include
+endif
+
 # ZF sources are C files that are built as C++ using the cc command.  The
 # reasons being:
 #  * files can stay .c
 #  * gcc does not enable exceptions nor link with stdcpp library (as opposed to
 #    C++).
-# XXX: ZF has no business requiring TRANSPORT_CONFIG_OPT_HDR.  We're pulling
-# in too much from Onload in order to get oo_resource_mmap() and the other
-# wrappers around /dev/onload ops.
 $(SOCKET_SHIM_OBJS): ZF_CFLAGS_COMPONENT := \
   $(ZF_CFLAGS_COMMON) \
   $(ZF_CXXFLAGS_COMMON) \
   -fvisibility=hidden \
-  -I$(ONLOAD_TREE)/src/include \
-  -I$(ONLOAD_UL_BUILD_DIR)/include \
-  -fPIC \
-   '-DTRANSPORT_CONFIG_OPT_HDR=<ci/internal/transport_config_opt_extra.h>'
+  $(ONLOAD_CFLAGS) \
+  -fPIC
 
 # Link the shim against the dynamic ZF library to make Runbench's life easier.
 # If the shim is ever distributed, Runbench can use that instead, and we'd be

--- a/src/lib/zf/zf.c
+++ b/src/lib/zf/zf.c
@@ -90,7 +90,7 @@ extern int zf_deinit(void)
 
 
 #include <ci/internal/syscall.h>
-#include "onload_version.h"
+#include ONLOAD_VERSION_HDR
 
 static const char* version =
   "TCPDirect Library version: "ZF_VERSION"\n"

--- a/src/tests/zf_internal/Makefile.inc
+++ b/src/tests/zf_internal/Makefile.inc
@@ -14,10 +14,6 @@ INT_BINS := $(SHARED_INT_BINS) $(STATIC_INT_BINS)
 $(SHARED_INT_BINS): $(BIN_SHARED)/%: $(OBJ_CURRENT)/%.o $(ZF_SHARED_LIB)
 $(STATIC_INT_BINS): $(BIN_STATIC)/%: $(OBJ_CURRENT)/%.o $(ZF_STATIC_LIB)
 
-ifdef ONLOAD_TREE
-  ONLOAD_CFLAGS := -I$(ONLOAD_TREE)/src/include
-endif
-
 # For compatibility with old compilers, use gnu99 rather than, say, c11.
 $(TEST_OBJS): ZF_CFLAGS_COMPONENT := -std=gnu99 $(ZF_CFLAGS_COMMON) $(ONLOAD_CFLAGS)
 

--- a/src/tests/zf_unit/Makefile.inc
+++ b/src/tests/zf_unit/Makefile.inc
@@ -42,12 +42,16 @@ UT_ALL := $(sort \
   $(UT_LOOP_JENKINS))
 
 
+ifdef ONLOAD_TREE
+  ONLOAD_CFLAGS  := -I$(ONLOAD_TREE)/src/include
+endif
+
 UT_OBJS := $(UT_ALL:%=$(OBJ_CURRENT)/%.o)
 $(UT_OBJS): $(ZF_SHARED_LIB_LINK)
 $(UT_OBJS): ZF_CFLAGS_COMPONENT := \
   $(ZF_CFLAGS_COMMON) \
   $(filter-out -fno-exceptions -fno-threadsafe-statics,$(ZF_CXXFLAGS_COMMON)) \
-  -I$(ONLOAD_TREE)/src/include \
+  $(ONLOAD_CFLAGS) \
   -I$(SRC_CURRENT)
 
 

--- a/src/tools/zf/Makefile.inc
+++ b/src/tools/zf/Makefile.inc
@@ -6,9 +6,13 @@ TOOL_OBJS := $(TOOLS:%=$(OBJ_CURRENT)/%.o)
 TOOL_BINS := $(TOOLS:%=$(BIN_ROOT)/%)
 STRIPPED_BINS := $(TOOLS:%=$(BIN_ROOT)/stripped/%)
 
+ifdef ONLOAD_TREE
+  ONLOAD_CFLAGS  := -I$(ONLOAD_TREE)/src/include
+endif
+
 $(TOOL_OBJS): ZF_CFLAGS_COMPONENT := \
   $(ZF_CFLAGS_COMMON) \
-  -I$(ONLOAD_TREE)/src/include \
+  $(ONLOAD_CFLAGS) \
   -g \
   $(ZF_CXXFLAGS_COMMON)
 


### PR DESCRIPTION
~~Built ontop of PR #22, but with those changes rebased onto the newest version of master. When #22 is rebased/merged I'll remove these extra commits, for now just focus on the 2 most recent commits.~~

### [1/2] Cleanup: Allow for relative path in ONLOAD_TREE

Not technically needed, but now something like `ONLOAD_TREE=../onload make` should work.

### [2/2] ON-15945: Build tcpdirect against system installed onload
If ONLOAD_TREE is set then the build will proceed as before, otherwise
now it will try to build against system installed libraries/headers.

Building with ZF_DEVEL=1 will still require setting ONLOAD_TREE due
since it includes some files from within onload's src tree.

## Testing done
Installed `onload` and `onload-devel` rpms, then built tcpdirect with `make`.