### PR TITLE
ON-15945: Add option to build RPM from system installed onload

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -33,10 +33,23 @@ The `${version}` variable can be git hexsha such as `d42f94d5` or a semver strin
 Execute the following command to create an RPM package from SRPM:
 
 ```bash
-rpmbuild --define "onload_tarball ${onload}" --rebuild ~/rpmbuild/SRPMS/tcpdirect-${version}-1.src.rpm
+rpmbuild --rebuild ~/rpmbuild/SRPMS/tcpdirect-${version}-1.src.rpm
 ```
 
-Here, the `${onload}` variable points to an Onload tarball, and `${version}` is the same as for `zf_make_official_srpm`.
+Here, the `${version}` variable is the same as for `zf_make_official_srpm`.
+The above command will build the tcpdirect package using the onload libraries
+installed as part of the `onload` rpm package, and the headers from the
+`onload-devel` package.
+
+If you wish to build the tcpdirect package either from a specific onload tarball
+or without installing the system packages, you can add the following to the
+invocation of `rpmbuild` above:
+
+```bash
+--define "onload_tarball ${onload}"
+```
+
+Where the `${onload}` variable points to an Onload tarball.
 
 ## How to run unit tests
 

--- a/scripts/tcpdirect_misc/tcpdirect.spec
+++ b/scripts/tcpdirect_misc/tcpdirect.spec
@@ -21,6 +21,9 @@ License:        MIT AND BSD-3-Clause AND LGPL-3.0
 URL:            https://github.com/Xilinx-CNS/tcpdirect
 Source0:        tcpdirect-%{pkgversion}.tgz
 BuildRequires:  gcc make
+%if 0%{!?onload_tarball:1}
+BuildRequires:  openonload onload-devel
+%endif
 
 Vendor:         Advanced Micro Devices, Inc.
 

--- a/scripts/zf_mkdist
+++ b/scripts/zf_mkdist
@@ -28,7 +28,9 @@ scripts
 usage() {
     echo
     echo "usage:"
-    echo "  $(basename $0) [options] <onload_tarball>"
+    echo "  $(basename $0) [options] [onload_tarball]"
+    echo
+    echo "(Installed onload & onload-devel utilised when onload_tarball omitted.)"
     echo
     echo "options:"
     echo "  --version <version>"
@@ -46,10 +48,12 @@ cleanup() {
 
 
 copy_files_to_tmpdir() {
-    mkdir -p "${onload_tmpdir}"
     mkdir -p "${zf_tmpdir}"
     tar cz -C "${top_dir}" ${copy_to_tmpdir} | tar xz -C ${zf_tmpdir}
-    cat "${onload_tarball}" | tar xz -C ${onload_tmpdir}
+    if [ -n "$onload_tarball" ]; then
+      mkdir -p "${onload_tmpdir}";
+      cat "${onload_tarball}" | tar xz -C ${onload_tmpdir};
+    fi
 }
 
 
@@ -99,7 +103,11 @@ build_and_copy_artifacts() {
     cd "${zf_tmpdir}"
     # shellcheck disable=SC2086
     make ${parallel} ${make_args}
-    build_tree=$(ls -d "${build_dir}"/gnu*)
+    if [ -n "$onload_tarball" ]; then
+      build_tree=$(ls -d "${build_dir}"/gnu*);
+    else
+      build_tree=$(ls -d "${build_dir}");
+    fi
     copy_artifacts "${build_tree}" "${artifact_dir}" "${build_type}"
 }
 
@@ -147,7 +155,9 @@ build_zf() {
       fi
   fi
 
-  export ONLOAD_TREE="$(ls -1d $onload_tmpdir/*)"
+  if [ -n "$onload_tarball" ]; then
+    export ONLOAD_TREE="$(ls -1d $onload_tmpdir/*)"
+  fi
   artifact_dir="${zf_tmpdir}/build/artifacts/"
   rm -rf ${artifact_dir}
   build_and_copy_artifacts "debug" ${artifact_dir}
@@ -186,7 +196,12 @@ if [ -z "$version" ]; then
     version=$(git rev-parse HEAD)
 fi
 
-[ $tarball_count -eq 1 ] || usage
+[ $tarball_count -eq 1 ] || [ -d /usr/include/ci ] || usage
+
+if $shim && [ -z "$onload_tarball" ]; then
+  echo "In order to build the socket shim, please supply an onload tarball";
+  usage;
+fi
 
 tmpdir=$(mktemp -d)
 onload_tmpdir="${tmpdir}/onload"


### PR DESCRIPTION
Previously, in order to build the tcpdirect binary rpm you would have to define the `onload_tarball` macro so that the build system would have all the requisite libraries and headers. Now that we have the `onload-devel` package (and have included citools.a in `onload`), we can use the system installed onload when building tcpdirect and do away with the macro.

The functionality of `onload_tarball` is still preserved in case a user wants to build from a specific version of onload but doesn't want to install it on their system. Additionally, if you want to build the socket shim using `zf_mkdist` you must specify the onload tarball to use as the shim requies `ZF_DEVEL=1` which in turn requires a full copy of the onload source code.

## Testing done
If `onload` and `onload-devel` packages were installed on the system I could successfully run `zf_mkdist` without specifying an onload tarball, and `rpmbuild --rebuild tcpdirect-*.src.rpm` was sufficient to build the binary rpm.
Otherwise the build system works the same as before.