### PR TITLE
ON-15724: replace release tag with alternative version

### DIFF
--- a/.github/workflows/perform_build.yml
+++ b/.github/workflows/perform_build.yml
@@ -14,8 +14,7 @@ jobs:
     timeout-minutes: 1
     outputs:
       tcpdirectBranch: ${{ steps.tcpdirectBranch.outputs.branch }}
-      onloadBranch: ${{ steps.onloadBranch.outputs.branch }}
-      onloadReleaseTag: ${{ steps.onloadReleaseTag.outputs.tag }}
+      onloadPublicTreeish: ${{ steps.onloadPublicTreeish.outputs.tag }}
       packetDrillBranch: ${{ steps.packetDrillBranch.outputs.branch }}
     steps:
       - name: tcpdirect
@@ -33,13 +32,9 @@ jobs:
         id: tcpdirectBranch
         run: echo "branch=$(yq -r '.products.TCPDirect.version' < $GITHUB_WORKSPACE/tcpdirect/versions.yaml)" >> "$GITHUB_OUTPUT"
 
-      - name: Extract onload branch name
-        id: onloadBranch
-        run: echo "branch=$(yq -r '.products.Onload.version' < $GITHUB_WORKSPACE/tcpdirect/versions.yaml)" >> "$GITHUB_OUTPUT"
-
-      - name: Extract onload release tag
-        id: onloadReleaseTag
-        run: echo "tag=$(yq -r '.products.Onload.release_tag' < $GITHUB_WORKSPACE/tcpdirect/versions.yaml)" >> "$GITHUB_OUTPUT"
+      - name: Extract public onload tree-ish
+        id: onloadPublicTreeish
+        run: echo "tag=$(yq -r '.products.Onload.public_tree_ish' < $GITHUB_WORKSPACE/tcpdirect/versions.yaml)" >> "$GITHUB_OUTPUT"
 
       - name: Extract packetDrill branch name
         id: packetDrillBranch
@@ -57,23 +52,12 @@ jobs:
         with:
           path: tcpdirect
 
-      - name: onload checkout
-        id: onloadCheckoutStep
-        continue-on-error: true
+      - name: onload checkout public tree-ish
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/onload
           path: onload
-          ref: ${{ needs.extract_branch_info.outputs.onloadBranch }}
-
-      - name: onload checkout tag
-        if: ${{ steps.onloadCheckoutStep.outcome == 'failure' &&
-                needs.extract_branch_info.output.onloadReleaseTag != 'null' }}
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.repository_owner }}/onload
-          path: onload
-          ref: ${{ needs.extract_branch_info.outputs.onloadReleaseTag }}
+          ref: ${{ needs.extract_branch_info.outputs.onloadPublicTreeish }}
 
       - name: packetdrill checkout
         uses: actions/checkout@v4

--- a/versions.yaml
+++ b/versions.yaml
@@ -8,7 +8,7 @@ products:
   Onload:
     version: 'onload-8.1'
     repo_source: 'git@github.com:Xilinx-CNS/onload_internal.git'
-    release_tag: 'v8.1.3'
+    public_tree_ish: 'v8_1'
   Packetdrill:
     version: 'tcpdirect-8.1'
     repo_source: 'git@github.com:Xilinx-CNS/packetdrill-tcpdirect.git'


### PR DESCRIPTION
Now that Xilinx-CNS/onload@v8_1 exists alongside the branch Xilinx-CNS/tcpdirect@v8_1, we want to use that for builds and testing instead. This change also renames the release tag mechanism with an alternative version string as that makes more sense.

### Testing Done
GHA [now fails](https://github.com/jfeather-amd/tcpdirect/actions/runs/10470331764/job/28995268477) (as expected), fixed by #35.