### PR TITLE
ON-16016: more gracefully handle missing libefcp.so

### DIFF
--- a/src/include/zf_internal/zf_state.h
+++ b/src/include/zf_internal/zf_state.h
@@ -16,10 +16,16 @@
     OP(register_intf) \
     OP(resolve)
 
+#define CP_FUNC_TYPE(x) \
+  decltype(ef_cp_##x)
+
+#define CP_FUNC_PTR_TYPE(x) \
+  decltype(&ef_cp_##x)
+
 struct zf_state {
   struct ef_cp_handle* cp_handle;
   struct {
-#define CP_FUNC_DEFINE_FUNC_PTR(x)  decltype(&ef_cp_##x) x;
+#define CP_FUNC_DEFINE_FUNC_PTR(x)  CP_FUNC_PTR_TYPE(x) x;
     FOR_EACH_EF_CP_FUNCTION(CP_FUNC_DEFINE_FUNC_PTR)
   } cp;
   void* efcp_so_handle;

--- a/src/lib/zf/zf.c
+++ b/src/lib/zf/zf.c
@@ -116,8 +116,11 @@ fail:
 extern int zf_deinit(void)
 {
   zf_state.cp.fini(zf_state.cp_handle);
-  dlclose(zf_state.efcp_so_handle);
-  FOR_EACH_EF_CP_FUNCTION(CP_FUNC_SET_TO_ERR);
+  if (zf_state.efcp_so_handle && zf_state.efcp_so_handle != &zf_state)
+  {
+    dlclose(zf_state.efcp_so_handle);
+    FOR_EACH_EF_CP_FUNCTION(CP_FUNC_SET_TO_ERR);
+  }
   zf_log_stderr();
   return 0;
 }

--- a/src/lib/zf/zf.c
+++ b/src/lib/zf/zf.c
@@ -48,6 +48,7 @@ int zf_init(void)
     if( ! zf_state.efcp_so_handle ) {
       zf_log_stack_err(NO_STACK, "%s: Failed to open ef_vi Control Plane: %s\n",
                       __func__, dlerror());
+      rc = -ENOENT;
       goto fail;
     }
 
@@ -57,6 +58,7 @@ int zf_init(void)
     if( ! zf_state.cp.x ) { \
       zf_log_stack_err(NO_STACK, "%s: Failed to link to ef_vi Control Plane: %s\n", \
                       __func__, #x); \
+      rc = -ENOENT; \
       goto fail1; \
     }
     FOR_EACH_EF_CP_FUNCTION(CP_FUNC_INIT_FUNC_PTR)

--- a/src/lib/zf/zf.c
+++ b/src/lib/zf/zf.c
@@ -9,9 +9,39 @@
 #include <zf_internal/attr.h>
 #include <zf_internal/private/zf_hal.h>
 #include <dlfcn.h>
+#include <functional>
 
+template <typename T>
+T _placeholder_cp_func() {
+  return (T)-1;
+}
 
-struct zf_state zf_state;
+template <>
+bool _placeholder_cp_func<bool>() {
+  return false;
+}
+
+template <>
+ef_cp_intf_verinfo _placeholder_cp_func<ef_cp_intf_verinfo>() {
+  return EF_CP_INTF_VERINFO_INIT;
+}
+
+#define ERR_EF_CP_FUNCTION(name) \
+  (CP_FUNC_PTR_TYPE(name)) \
+  &_placeholder_cp_func<std::function<CP_FUNC_TYPE(name)>::result_type>
+
+#define ERR_EF_CP_FUNCTION_INIT(name) \
+  .name = ERR_EF_CP_FUNCTION(name),
+
+#define CP_FUNC_SET_TO_ERR(name) zf_state.cp.name = ERR_EF_CP_FUNCTION(name);
+
+struct zf_state zf_state = (struct zf_state) {
+  .cp_handle = NULL,
+  .cp = {
+    FOR_EACH_EF_CP_FUNCTION(ERR_EF_CP_FUNCTION_INIT)
+  },
+  .efcp_so_handle = NULL
+};
 
 int zf_init(void)
 {
@@ -76,6 +106,7 @@ int zf_init(void)
 
 fail1:
   dlclose(zf_state.efcp_so_handle);
+  FOR_EACH_EF_CP_FUNCTION(CP_FUNC_SET_TO_ERR);
 fail:
   zf_log_stderr();
   return rc;
@@ -86,6 +117,7 @@ extern int zf_deinit(void)
 {
   zf_state.cp.fini(zf_state.cp_handle);
   dlclose(zf_state.efcp_so_handle);
+  FOR_EACH_EF_CP_FUNCTION(CP_FUNC_SET_TO_ERR);
   zf_log_stderr();
   return 0;
 }


### PR DESCRIPTION
If libefcp.so can't be found then zf_init will fail, but won't report this to the program that called `zf_init`. This meant that any programs that failed for this reason would not know that they failed, as the `rc` returned would be that from the already non-negative `zf_hal_init` call earlier in the function. A side effect of this was that, as the `zf_state.cp.*` function pointers hadn't been initialised, an app would segfault. 

To solve these problems:
1. 7a4fca63878b03f3dadd62a372115ade2d30690f correctly reports failure of `zf_init` in such cases
2. 6f324d6ffddfc375da7003e8cb92f8a738bf21d3 provides default implementations which, to my best effort, will hopefully return the standard "this failed" values
3. 6aabee5fd440f1d812c7ede2650fee74623796f3 fixes an unearthed issue where `dlclose` would be unconditionally called, even though it is not safe to do so (and resulted in quite a few test case failures), the condition used encodes the assumption that [zf_emu sets the handle to `&zf_state`](https://github.com/Xilinx-CNS/tcpdirect/blob/d088db7e9d0b170ee8c4f96724ee2382381e091f/src/lib/zf/private/zf_emu.c#L2883).

### Testing Done
Testing without libefcp.so:
<details><summary>Original output (before all commits)</summary>
<p>

```
$ ZF_ATTR="interface=enp4s0f0" ./build/gnu_x86_64-zf-devel/bin/zf_apps/static/zfsink dellr630bb-l:8080
zf_init: Failed to open ef_vi Control Plane: libefcp.so: cannot open shared object file: No such file or directory
Segmentation fault (core dumped)

(gdb output)
Program received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
Missing separate debuginfos, use: dnf debuginfo-install glibc-2.34-100.el9.x86_64
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x000000000045dd59 in zf_cplane_get_ifindex (interface=<optimized out>) at src/lib/zf/cplane.c:227
#2  0x000000000046029a in zf_stack_alloc (attr=0x49ead0, stack_out=stack_out@entry=0x7fffffffd9d0) at src/lib/zf//private/stack_alloc.c:766
#3  0x0000000000437b07 in main (argc=1, argv=0x7fffffffdbb0) at src/tests/zf_apps/zfsink.c:294
```

</p>
</details> 

<details><summary>With 7a4fca63878b03f3dadd62a372115ade2d30690f (only)</summary>
<p>

```
$ ZF_ATTR="interface=enp4s0f0" ./build/gnu_x86_64-zf-devel/bin/zf_apps/static/zfsink dellr630bb-l:8080
zf_init: Failed to open ef_vi Control Plane: libefcp.so: cannot open shared object file: No such file or directory
ERROR: main: ZF_TRY(zf_init()) failed
ERROR: at src/tests/zf_apps//zfsink.c:285
ERROR: rc=-1 (Operation not permitted) errno=2
Aborted (core dumped)
```

</p>
</details> 

<details><summary>With 6f324d6ffddfc375da7003e8cb92f8a738bf21d3 (only)</summary>
<p>

```
$ ZF_ATTR="interface=enp4s0f0" ./build/gnu_x86_64-zf-devel/bin/zf_apps/static/zfsink dellr630bb-l:8080
zf_init: Failed to open ef_vi Control Plane: libefcp.so: cannot open shared object file: No such file or directory
ERROR: main: ZF_TRY(zf_stack_alloc(attr, &stack)) failed
ERROR: at src/tests/zf_apps//zfsink.c:294
ERROR: rc=-1 (Operation not permitted) errno=2
Aborted (core dumped)
```

</p>
</details> 


I have also tested that these commits work when onload/libefcp.so is installed, but it's a less interesting test case to show off for each of them individually (tested with `nc` on the other end):

```
$ ZF_ATTR="interface=enp4s0f0" ./build/gnu_x86_64-zf-devel/bin/zf_apps/static/zfsink dellr630bb-l:8080
Polling reactor
Received datagram of length 1
^C
```