### PR TITLE
cleanup: update distfiles

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,9 +1,19 @@
-tcpdirect-8.1.3
+tcpdirect-9.0.0
 ---------------
 
-See corresponding onload-8.1.3 changelog for changes in OS support.
+See corresponding Onload changelog for changes in OS support.
 
-Changes:
+ON-1440: use new public control plane API
+ON-15038: view zf attributes in zf_stackdump
+ON-15668: add time checking for MAC lookup to better enforce ARP timeout
+ON-15695: ship tcpdirect as source code with refreshed packaging
+ON-15895: handle TX completions for in-flight retransmitted packets
+
+
+tcpdirect-8.1.3.8
+-----------------
+
+See corresponding onload-8.1.3 changelog for changes in OS support.
 
 ON-13593: add udp_ttl attribute to control TTL on sent UDP packets
 ON-15421: stop exporting ef_vi symbols in the dynamic library
@@ -15,8 +25,6 @@ tcpdirect-8.1.2.38
 
 See corresponding onload-8.1.2 changelog for changes in OS support.
 
-Bug fixes:
-
 ON-13158: avoid CTPIO when there won't be space for fallback
 ON-14012: zfsend requires 2 arguments; avoid segfault if only 1
 
@@ -26,8 +34,6 @@ tcpdirect-8.1.1.23
 
 See corresponding onload-8.1.1 changelog for changes in OS support.
 
-Bug fixes:
-
 ON-14981: fix insufficient packet buffer allocation observable in some configs
 
 
@@ -36,19 +42,12 @@ tcpdirect-8.1.0.19
 
 See corresponding onload-8.1.0 changelog for changes in OS support.
 
-Features:
-
-ON-14799: add transmit warming for X3522
-
-Bug fixes:
-
 ON-14313: don't force PIO on efct
+ON-14799: add transmit warming for X3522
 
 
 tcpdirect-8.0.2.11
 ------------------
-
-Bugs fixed:
 
 ON-14431: X3522: fix discard handling
 
@@ -56,17 +55,12 @@ ON-14431: X3522: fix discard handling
 tcpdirect-8.0.1.2
 -----------------
 
-The OS and NIC support list has changed and corresponds to that supporte
+The OS and NIC support list has changed and corresponds to that supported
 by OpenOnload-8.0.1.
 
-Features:
-
-ON-14286: include version information in zf_stackdump
-
-Bugs fixed:
-
-ON-14306: fix segfault in zft_send_single_warm
 ON-14236: restore debian packaging
+ON-14286: include version information in zf_stackdump
+ON-14306: fix segfault in zft_send_single_warm
 
 
 tcpdirect-8.0.0.30
@@ -86,19 +80,14 @@ Remove support for:
  - SuSE Linux Enterprise Server 12
  - Debian 9 "Stretch"
 
-Features:
-
 ON-9207: add zf_stack_query_feature() to query PIO and CTPIO support
 ON-9301: add zfsink -p option to print ZF attributes after stack creation
+ON-11543: add per-stack and per-zocket retransmit counters in zf_stackdump
+ON-12776: tcp tx: prevent doing extra copy after every CTPIO or DMA
 ON-12823: add min/max/median/%-ile stats to zftcppingpong/zfudppingpong
 ON-13375: allow creation of TX/RX-only stacks with tx/rx_ring_max=0
 ON-13388: add zf_send application
 X3-447: allow for arbitrary iovec array len
-
-Bugs fixed:
-
-ON-11543: add per-stack and per-zocket retransmit counters in zf_stackdump
-ON-12776: tcp tx: prevent doing extra copy after every CTPIO or DMA
 
 
 See onload-7.1.3 change log for changes in prior versions of TCP Direct

--- a/doc/ReleaseNotes
+++ b/doc/ReleaseNotes
@@ -1,72 +1,36 @@
-TCPDirect-8.1.3
+TCPDirect-9.0.0
 ===============
 
-  This is a minor update release of TCPDirect to match Onload-8.1.3 and
-  including bug fixes since TCPDirect-8.1.2.38. See changelog for details.
-
-
-TCPDirect-8.1.2.38
-==================
-
-  This is a minor update release of TCPDirect to match Onload-8.1.2 and
-  including bug fixes since TCPDirect-8.1.1.23. See changelog for details.
-
-
-TCPDirect-8.1.1.23
-==================
-
-  This is a minor update release of TCPDirect to match Onload-8.1.1,
-  also including a bug fix. See changelog for details.
-
-
-TCPDirect-8.1.0.19
-==================
-
-  This is a feature release of TCPDirect to be used with Onload-8.1.0.
-
-
-TCPDirect-8.0.2.11
-==================
-
-  This is a minor update release of TCPDirect that includes fixes since
-  TCPDirect-8.0.1.2.
-
-
-TCPDirect-8.0.1.2
-=================
-
-  This is a minor update release of TCPDirect that includes fixes and other
-  changes since TCPDirect-8.0.0.304.
-
-
-TCPDirect-8.0.0.304
-===================
-
   This is a feature release of TCPDirect that includes fixes and other changes
-  since the version of TCPDirect included in OpenOnload-7.1.3.202.
+  since the TCPDirect-8.1.3.8.
 
-  This version of TCPDirect must be used with the corresponding version
-  of Onload, OpenOnload-8.0.0.
+  See the ChangeLog for a list of fixes.
 
-
-Network adapter and Linux distribution support
-----------------------------------------------
-
-  This packages is supported on all network adapters and operating systems
-  supported by OpenOnload-8.0.0.
+  TCPDirect must be used with a matching version of Onload, in this case
+  Onload version 9.0.0. The network adapter and operating system support
+  derives from those supported by Onload.
 
 
-New features
-------------
+Public Onload/ef_vi control plane API
+-------------------------------------
 
- - ztacks may be configured as rx-only or tx-only by setting tx_ring_max or
-   rx_ring_max respectively to 0.
-
- - zf_stack_query_feature() has been added to allow PIO and CTPIO support to
-   be queries at runtime.
+  The Onload control plane in this Onload-9.0.0 is presented via a new
+  public API that can be used by ef_vi applications. As an ef_vi application,
+  TCPDirect now uses this API to query the control plane server.
 
 
-Installation
+TCPDirect distributed as source code
+------------------------------------
+
+  TCPDirect has been relicensed with the MIT open source license and
+  since v9.0.0 is shipped as a source package rather than a binary package.
+
+  The packaging for Onload and TCPDirect has been refreshed to allow
+  suitable new build and installation workflows for the TCPDirect source
+  package.
+
+
+Installation (TBD: update this section)
 ------------
 
   To install TCPDirect from a tarball:


### PR DESCRIPTION
Note:

- Installation instructions require subsequent updates.
- Changes are too few and of ambiguous categorisation to split into sublists - 'feature' and 'bug fixes' lists merged in recent release changelogs to be less jarring to read as a whole.