### PR TITLE
ON-16084: Don't include ReleaseNotes in packages

### DIFF
--- a/scripts/tcpdirect_misc/tcpdirect-extract-notes
+++ b/scripts/tcpdirect_misc/tcpdirect-extract-notes
@@ -26,12 +26,6 @@ else
     err "No Changelog file found in Tarball"
 fi
 
-if [ -f "$dir/ReleaseNotes" ]; then
-    try mv "$dir/ReleaseNotes" "$dst/$dir-ReleaseNotes.txt"
-else
-    err "No ReleaseNotes file found in Tarball"
-fi
-
 if [ -f "$dir/LICENSE" ]; then
     try mv "$dir/LICENSE" "$dst/$dir-LICENSE.txt"
 else

--- a/scripts/zf_make_tarball
+++ b/scripts/zf_make_tarball
@@ -36,12 +36,7 @@ make_release_package() {
 
 
     # Add documents to tarball
-    # Currently only ReleaseNotes exists (in a separate branch), so checks are added for each file
     if [ -d "$doc_dir" ]; then
-        if [ -f "${doc_dir}/ReleaseNotes" ]; then
-            cp "${doc_dir}/ReleaseNotes" "${stage_dir}"
-        fi
-
         if [ -f "${doc_dir}/LICENSE" ]; then
             cp "${doc_dir}/LICENSE" "${stage_dir}"
         fi


### PR DESCRIPTION
## Testing done
Ran jenkins pipeline. No `ReleaseNotes.txt` in the artifacts, and unzipping one of the `.zip` packages showed that it was not included:
```
$ unzip tcpdirect-8.1.3.5-srpm-doxbox.zip
Archive:  tcpdirect-8.1.3.5-srpm-doxbox.zip
  inflating: tcpdirect-8.1.3.5-1.src.rpm
  inflating: tcpdirect-8.1.3.5-ChangeLog.txt
  inflating: tcpdirect-8.1.3.5-LICENSE.txt
```