### PR TITLE
Cleanup: Actually build ndebug when building from installed packages

### DIFF
--- a/scripts/zf_mkdist
+++ b/scripts/zf_mkdist
@@ -98,8 +98,7 @@ build_and_copy_artifacts() {
     fi
 
     build_dir="${zf_tmpdir}"/build
-    rm -rf "${build_dir}"/onload
-    rm -rf "${build_dir}"/gnu*
+    rm -rf "${build_dir}"
     cd "${zf_tmpdir}"
     # shellcheck disable=SC2086
     make ${parallel} ${make_args}


### PR DESCRIPTION
Previously zf_mkdist would just rm certain sub-directories from build tree before starting a different build type. This was fine when all builds used an onload tarball. However, now that tcpdirect can be built against a system installed onload this can cause issues as these subdirectories don't necessarily exist. This can be resolved by rm-ing the entire build directory and continuing from that point.

## Testing done
Manual inspection. Previous when calling `zf_mkdist` it would say that it was build ndebug binaries, but then `make` would say `nothing to be done for all` (or similar) and grepping for `-DNDEBUG` in the build logs wouldn't get anything.
Now the `NDEBUG` builds are actually happening