### PR TITLE
ON-16089: Remove non-artifact build directories in zf_mkdist

### DIFF
--- a/scripts/zf_mkdist
+++ b/scripts/zf_mkdist
@@ -98,7 +98,8 @@ build_and_copy_artifacts() {
     fi
 
     build_dir="${zf_tmpdir}"/build
-    rm -rf "${build_dir}"
+    rm -rf "${build_dir}"/onload
+    rm -rf "${build_dir}"/gnu*
     cd "${zf_tmpdir}"
     # shellcheck disable=SC2086
     make ${parallel} ${make_args}

--- a/scripts/zf_mkdist
+++ b/scripts/zf_mkdist
@@ -98,8 +98,14 @@ build_and_copy_artifacts() {
     fi
 
     build_dir="${zf_tmpdir}"/build
-    rm -rf "${build_dir}"/onload
-    rm -rf "${build_dir}"/gnu*
+    # Clean the build directory, but ensure we don't delete the artifacts from a
+    # previous build stage.
+    find "${build_dir}" -maxdepth 1 -mindepth 1 -type d |
+      while read -r d; do
+        if [ "$(realpath "${d}")" != "$(realpath "${artifact_dir}")" ]; then
+          rm -rf "${d}";
+        fi
+      done
     cd "${zf_tmpdir}"
     # shellcheck disable=SC2086
     make ${parallel} ${make_args}


### PR DESCRIPTION
I broke the build system in #44 by deleting the produced artifacts while cleaning the build directory for the next part of the process. This approach expands on the previous one by removing all subdirectories of `build_dir` that aren't equal to `artifact_dir`

## Testing done
Manual testing using both onload tarball and install rpms. Here is the list of files in the new tarball built with the shim:
```
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/debug/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/debug/bin/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/debug/bin/zf_stackdump
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/debug/lib/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/debug/lib/libonload_zf.so.1
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/debug/lib/libonload_zf_static.a
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/debug/lib/libonload_zf.so
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/release/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/release/bin/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/release/bin/zf_stackdump
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/release/lib/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/release/lib/libonload_zf.so.1
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/release/lib/libonload_zf_static.a
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/release/lib/libonload_zf.so
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/shim/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/shim/libzf_sockets.so
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/scripts/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/scripts/zf_install
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/scripts/zf_uninstall
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/scripts/zf_debug
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/scripts/tcpdirect.spec
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/LICENSE
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/ChangeLog
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/muxer.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/x86.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/types.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/zf.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/zf_alts.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/zf_ds.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/zf_platform.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/zf_reactor.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/zf_stack.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/zf_tcp.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/zf_udp.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/attr.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/sysdep/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/include/zf/sysdep/x86.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/Makefile
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/Makefile.inc
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/zf_utils.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/zfaltpingpong.c
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/zfsend.c
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/zfsink.c
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/zftcpmtpong.c
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/zftcppingpong.c
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/zfudppingpong.c
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/zf_stats.c
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/zf_stats.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/zf_timer.c
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/zf_timer.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/zf_apps/Makefile-top.inc
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/trade_sim/
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/trade_sim/Makefile
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/trade_sim/Makefile.inc
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/trade_sim/README
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/trade_sim/ct_rx.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/trade_sim/trader_tcpdirect_ds_efvi.c
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/trade_sim/trader_tcpdirect_ds_efvi_ct_rx.c
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/trade_sim/utils.c
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/trade_sim/utils.h
zf-86dc1ffb921bcf33061d723a721b0a4e77332754/src/tests/trade_sim/Makefile-top.inc
```
Note that is has release and debug versions of `libonload_zf.so` and `libzf_sockets.so`