### PR TITLE
ON-16094: Ensure complete tmp dir is cleaned up at end of build

### DIFF
--- a/scripts/zf_mkdist
+++ b/scripts/zf_mkdist
@@ -58,10 +58,10 @@ copy_files_to_tmpdir() {
 
 
 grab_artifacts_from_tmpdir() {
-    tmpdir="${zf_tmpdir}/build/artifacts"
+    artifact_tmpdir="${zf_tmpdir}/build/artifacts"
     local_dir="${top_dir}/build/artifacts"
     mkdir -p "${local_dir}"
-    tar cz -C "${tmpdir}" . | tar zx -C "${local_dir}"
+    tar cz -C "${artifact_tmpdir}" . | tar zx -C "${local_dir}"
 }
 
 make_release_package() {
@@ -198,7 +198,7 @@ if $shim && [ -z "$onload_tarball" ]; then
   usage;
 fi
 
-tmpdir=$(mktemp -d)
+declare -r tmpdir=$(mktemp -d)
 onload_tmpdir="${tmpdir}/onload"
 zf_tmpdir="${tmpdir}/zf"
 trap cleanup EXIT


### PR DESCRIPTION
Testing done with change reports entire tmp dir is being cleaned up:
```
$ ./scripts/zf_mkdist --shim --version fbeb769bf0bfda9e7e042779c9272646b6b57213 onload/onload-a42bb29e3e8e.tgz
...
zf-fbeb769bf0bfda9e7e042779c9272646b6b57213/src/tests/trade_sim/trader_tcpdirect_ds_efvi.c
zf-fbeb769bf0bfda9e7e042779c9272646b6b57213/src/tests/trade_sim/trader_tcpdirect_ds_efvi_ct_rx.c
zf-fbeb769bf0bfda9e7e042779c9272646b6b57213/src/tests/trade_sim/utils.c
zf-fbeb769bf0bfda9e7e042779c9272646b6b57213/src/tests/trade_sim/utils.h
Written zf-fbeb769bf0bfda9e7e042779c9272646b6b57213.tgz
Deleting /tmp/tmp.Lk9Zp9UOxR
```

Example succeeding build log from runbench without change shows only artifact dir is being cleaned up:
```
...
21:49:17.816	zf-03cff7ff8f3c/src/tests/trade_sim/trader_tcpdirect_ds_efvi_ct_rx.c
21:49:17.816	zf-03cff7ff8f3c/src/tests/trade_sim/utils.c
21:49:17.816	zf-03cff7ff8f3c/src/tests/trade_sim/utils.h
21:49:17.816	Written zf-03cff7ff8f3c.tgz
21:49:17.816	Deleting /tmp/tmp.uNGNsan5iS/zf/build/artifacts
```
http://xcb-rb-logs.xilinx.com/output?fi=3367210&job=51&offset=26073

Runbench test pending:
http://xcb-rb-logs.xilinx.com/users/sianj/results/2024/10/04/0_dibench_14-34-00