### PR TITLE
ON-15695: improve developer documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing guidelines
+
+Thank you for taking your time to improve TCPDirect. We would appreciate if you
+follow the contributing guidelines to make review of changes easier.
+
+## Submitting changes
+
+1. Fork TCPDirect repository on https://github.com/Xilinx-CNS/tcpdirect
+2. Make local short-lived branch off of public master.
+3. Develop on branch locally. Please describe the changes you have made in
+the commit messages.
+4. Try to follow the coding conventions used in the files you edit.
+5. Check that the TCPDirect Unit Tests pass. See
+[DEVELOPING.md # How to run unit tests](./DEVELOPING.md#how-to-run-unit-tests)
+for further instructions.
+6. Push branch to your fork of TCPDirect repository.
+7. Create a new Pull Request. Please describe what feature testing you have done.
+8. Address review comments.
+9. You need to get sign-off of two other developers before the Pull Request
+can be merged.
+
+## Summary of coding conventions
+
+In general try to follow the style that is used in the file.
+Most of the files use:
+
+1. Line length limit of 79 characters.
+2. Two space indentation.
+3. C style comments (no C++ style comments).
+4. Opening braces are not put on their own line.
+5. No space between keyword and bracket.
+
+For instance,
+
+```c
+/* This is a comment */
+if( ! conditional_expr ) {
+  statement1;
+  statement2;
+}
+```
+
+## Footnotes
+
+```yaml
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
+```

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -52,9 +52,7 @@ $ sudo sysctl vm.nr_hugepages=4096
 
 ## Footnotes
 
-```
-# SPDX-License-Identifier: MIT
-# SPDX-FileCopyrightText: (c) 2020-2024 Advanced Micro Devices, Inc.
-#
-# Internal documentation
+```yaml
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
 ```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+doc/LICENSE

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# TCPDirect
+
+AMD TCPDirect is highly accelerated network middleware. It uses similar techniques to Onload, but delivers lower latency. In order to achieve this, TCPDirect supports a reduced feature set and uses a proprietary API.
+
+AMD TCPDirect should be used with corresponding versions of Onload®️ at https://github.com/Xilinx-CNS/onload.
+
+
+## Features
+
+* User-space: TCPDirect can be used by unprivileged user-space applications.
+* Kernel bypass: Data path operations do not require system calls.
+* Low CPU overhead: Data path operations consume very few CPU cycles.
+* Low latency: Suitable for low latency applications.
+* High packet rates: Supports millions of packets per second per core.
+* Zero-copy: Particularly efficient for filtering and forwarding applications.
+* Flexibility: Supports many use cases.
+
+
+## Installation and Quick Start Guide
+
+Recent releases of TCPDirect are distributed as source code. Instructions for building, packaging and installing may be found in [DEVELOPING.md](DEVELOPING.md)
+
+
+## Support
+
+The publicly-hosted repository is a community-supported project. When raising
+issues on this repository it is expected that users will be running
+from the head of the git tree to pick up recent changes.
+
+Supported releases of TCPDirect are available from
+<https://www.xilinx.com/support/download/nic-software-and-drivers.html#tcpdirect>.
+Please raise issues on _supported releases_ of TCPDirect with
+<support-nic@amd.com>.
+
+
+## Contributions
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md)
+
+
+## Footnotes
+
+```yaml
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
+```


### PR DESCRIPTION
Make the TCPDirect github look more like the Onload repo.