### PR TITLE
ON-16199: Set ownership on intermediate srpm tarballs

### DIFF
--- a/scripts/zf_make_official_srpm
+++ b/scripts/zf_make_official_srpm
@@ -76,7 +76,7 @@ trap cleanup EXIT
 
 # Create a tarball in tmpdir.
 # shellcheck disable=SC2086
-try tar -c -C "${top_dir}" --transform "s,^,${zf_prefix}/,S" -f "${zf_tarball}" -- ${tarball_files_from}
+try tar -c -C "${top_dir}" --owner=root --group=root --transform "s,^,${zf_prefix}/,S" -f "${zf_tarball}" -- ${tarball_files_from}
 
 # Patch and put the SPEC file in tmpdir.
 # shellcheck disable=SC2046
@@ -87,7 +87,7 @@ try sed \
   > "${tmpdir}/${zf_prefix}/${zf_spec}"
 
 # Add the patched SPEC file in the tarball.
-try tar -v -C "${tmpdir}" --append -f "${zf_tarball}" -- "${zf_prefix}/${zf_spec}"
+try tar -v -C "${tmpdir}" --owner=root --group=root --append -f "${zf_tarball}" -- "${zf_prefix}/${zf_spec}"
 
 # Compress the tarball.
 try gzip -v "${zf_tarball}"


### PR DESCRIPTION
## Testing done

Not sure whether it is possible to easily test without the users/groups it complains.

### Before
On the old version manually extracting out the tarball from the rpm and checking file ownership shows bad values:
```
$ rpm2cpio tcpdirect-9.0.1.27-1.src.rpm | cpio -idmv
tcpdirect-9.0.1.27.tgz
tcpdirect.spec
933 blocks
$ tar -tvf tcpdirect-9.0.1.27.tgz | head
-rw-r--r-- xcb-jenkins-onload/sflr 397 2024-11-21 09:50 tcpdirect-9.0.1.27/versions.yaml
-rw-r--r-- xcb-jenkins-onload/sflr 2716 2024-11-21 09:50 tcpdirect-9.0.1.27/Makefile
-rw-r--r-- xcb-jenkins-onload/sflr 1678 2024-11-21 09:50 tcpdirect-9.0.1.27/Makefile.onload
-rw-r--r-- xcb-jenkins-onload/sflr  547 2024-11-21 09:50 tcpdirect-9.0.1.27/Makefile-top.inc
drwxr-sr-x xcb-jenkins-onload/sflr    0 2024-11-21 09:59 tcpdirect-9.0.1.27/doc/
-rw-r--r-- xcb-jenkins-onload/sflr 3040 2024-11-21 09:50 tcpdirect-9.0.1.27/doc/ChangeLog
-rw-r--r-- xcb-jenkins-onload/sflr 10789 2024-11-21 09:50 tcpdirect-9.0.1.27/doc/LICENSE
-rw-r--r-- xcb-jenkins-onload/sflr  3487 2024-11-21 09:50 tcpdirect-9.0.1.27/doc/ReleaseNotes
drwxr-sr-x xcb-jenkins-onload/sflr     0 2024-11-21 09:59 tcpdirect-9.0.1.27/src/
drwxr-sr-x xcb-jenkins-onload/sflr     0 2024-11-21 09:59 tcpdirect-9.0.1.27/src/include/
```

### After
With this fix the files have the expected ownership
```
[tcrawley@dellr630am tcpdirect]$ ./scripts/zf_make_official_srpm
mkdir: created directory '/tmp/zf_make_official_srpm.PtqTf5Bv/tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713'
mkdir: created directory '/tmp/zf_make_official_srpm.PtqTf5Bv/tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713/scripts'
mkdir: created directory '/tmp/zf_make_official_srpm.PtqTf5Bv/tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713/scripts/tcpdirect_misc'
tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713/scripts/tcpdirect_misc/tcpdirect.spec
/tmp/zf_make_official_srpm.PtqTf5Bv/tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713.tar:      76.9% -- replaced with /tmp/zf_make_official_srpm.PtqTf5Bv/tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713.tar.gz
renamed '/tmp/zf_make_official_srpm.PtqTf5Bv/tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713.tar.gz' -> '/tmp/zf_make_official_srpm.PtqTf5Bv/tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713.tgz'
Wrote: /home/tcrawley/rpmbuild/SRPMS/tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713-1.src.rpm
Deleting /tmp/zf_make_official_srpm.PtqTf5Bv
[tcrawley@dellr630am tcpdirect]$ rpm2cpio ~/rpmbuild/SRPMS/tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713-1.src.rpm | cpio -idmv
tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713.tgz
tcpdirect.spec
949 blocks
[tcrawley@dellr630am tcpdirect]$ tar -tvf tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713.tgz
-rw-r--r-- root/root       397 2024-11-21 16:24 tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713/versions.yaml
-rw-r--r-- root/root      2716 2024-11-21 16:24 tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713/Makefile
-rw-r--r-- root/root      1678 2024-11-21 16:24 tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713/Makefile.onload
-rw-r--r-- root/root       547 2024-07-26 16:15 tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713/Makefile-top.inc
drwxr-xr-x root/root         0 2024-11-21 16:24 tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713/doc/
-rw-r--r-- root/root      3040 2024-11-21 16:24 tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713/doc/ChangeLog
-rw-r--r-- root/root     10789 2024-03-18 16:27 tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713/doc/LICENSE
-rw-r--r-- root/root      3487 2024-11-21 16:24 tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713/doc/ReleaseNotes
drwxr-xr-x root/root         0 2024-10-04 15:04 tcpdirect-d9ffa1f75f8ffa8345f0e2b1b7a6aa92e9258713/src/
...
```