### PR TITLE
ON-16211: Use proper SONAME for libefcp

### DIFF
--- a/src/lib/zf/zf.c
+++ b/src/lib/zf/zf.c
@@ -74,7 +74,7 @@ int zf_init(void)
     goto fail;
 
   if( ! zf_state.efcp_so_handle ) {
-    zf_state.efcp_so_handle = dlopen("libefcp.so", RTLD_NOW);
+    zf_state.efcp_so_handle = dlopen("libefcp.so.1", RTLD_NOW);
     if( ! zf_state.efcp_so_handle ) {
       zf_log_stack_err(NO_STACK, "%s: Failed to open ef_vi Control Plane: %s\n",
                       __func__, dlerror());


### PR DESCRIPTION
Closes #55 .

## Testing done
* Built zf using installed onload.
* Moved libefcp* into a new location (`/tmp/`) and removed `libefcp.so` leaving `libefcp.so.1` and `libefcp.so.1.0.0`
* Ran zfsink

Without this patch it fails to load to the library, with the patch it progresses past that point.