### PR TITLE
ON-15400: Fix unit test breakage

### DIFF
--- a/src/tests/zf_unit/zfattrs.c
+++ b/src/tests/zf_unit/zfattrs.c
@@ -170,6 +170,7 @@ static void test(struct zf_stack* stack, struct zf_attr* attr,
 
 
 #define ITERS 50
+#define NUM_LOG_FILE_TESTS 6
 
 int main(void)
 {
@@ -181,7 +182,7 @@ int main(void)
 
   char non_existent_dir[] = "/path/to/non-existent-dir";
 
-  plan(TESTS_PER_ITER * ITERS);
+  plan(TESTS_PER_ITER * ITERS + NUM_LOG_FILE_TESTS);
 
   int rc = zf_init();
   if( rc != 0 )


### PR DESCRIPTION
This fixes a unit test failure where more than the number of expected tests are run. Introduced in commit:
25232a5b0e6ee016d30a24e95bd280cc82af2505


# testing

Ran `make testmisc` which runs the zf_attrs unit tests. They pass.