### PR TITLE
ON-16235: continue tests on fail in GHA and expand slow test set

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -39,4 +39,4 @@ runs:
         TIMEOUT_MULTIPLIER: ${{ inputs.test_timeout_multiplier }}
         ZF_RUN_SLOW_TESTS: ${{ fromJSON(inputs.run_slow_tests) && 1 || 0 }}
         ZF_DEVEL: 1
-      run: UT_OUTPUT="$GITHUB_STEP_SUMMARY" make -j $(nproc) test
+      run: UT_OUTPUT="$GITHUB_STEP_SUMMARY" make -j $(nproc) -k test

--- a/src/tests/zf_unit/Makefile.inc
+++ b/src/tests/zf_unit/Makefile.inc
@@ -28,10 +28,12 @@ UT_OTHER := zftcppingpong2
 UT_SCRIPTS := zfudppingpong.sh zf_tcp_sanity.sh packetdrill.sh zfsend.sh zfudpttl.sh
 
 # List of tests to skip unless ZF_RUN_SLOW_TESTS=1 (defaults to 1)
-# NOTE: `zfovl` is not actually slow, but rather unstable on slow machines.
+# NOTE: Some tests are not actually slow, but rather unstable on slow machines:
+# - `zfovl`
+# - `zfquiesce_waittw`
 UT_SLOW := zf_superbuf_fallback zf_superbuf_stack_destroy zf_superbuf_locality \
            zf_superbuf_n_sleep zf_superbuf_sleepy_stacks zftcptimeouts \
-	   zfreactorloop zfstackfree zfrxtable zftcprx zfovl
+           zfreactorloop zfstackfree zfrxtable zftcprx zfovl zfquiesce_waittw
 
 # List of tests to skip unless ZF_RUN_UNSTABLE_TESTS=1 (defaults to 0)
 UT_UNSTABLE := zftimestamping $(UT_SCRIPTS)


### PR DESCRIPTION
I found that, during merging of the corresponding onload change, the `zfquiesce_waittw` test failed, so have added it to the slow tests. At the same time, I spotted that I had accidentally dropped the `-k` from the `make test` invocation to continue running through tests even if one fails.

### Testing Done
- [GHA pass](https://github.com/jfeather-amd/tcpdirect/actions/runs/12670600906/job/35310600272)
- `make testmisc` with `ZF_RUN_SLOW_TESTS=0` skips `zfquiesce_waittw`