### PR TITLE
ON-16265: Set no-poison vi flag when ctpio_mode=sf-np

### DIFF
--- a/src/lib/zf/private/stack_alloc.c
+++ b/src/lib/zf/private/stack_alloc.c
@@ -290,7 +290,7 @@ static int zf_stack_init_pio(struct zf_stack_impl* sti, struct zf_attr* attr,
 
 static int zf_stack_init_ctpio_stack_config(struct zf_stack_impl* sti,
                                             struct zf_attr* attr,
-                                            unsigned* ctpio_mode)
+                                            int* ctpio_mode)
 {
   zf_stack* st = &sti->st;
 
@@ -331,7 +331,7 @@ static int zf_stack_init_ctpio_stack_config(struct zf_stack_impl* sti,
 
 static int zf_stack_init_ctpio_nic_config(zf_stack_impl* sti,
                                           struct zf_attr* attr,
-                                          unsigned ctpio_mode, int nicno, 
+                                          int ctpio_mode, int nicno, 
                                           unsigned* vi_flags)
 {
   zf_stack* st = &sti->st;
@@ -358,7 +358,7 @@ static int zf_stack_init_ctpio_nic_config(zf_stack_impl* sti,
 
   if( ctpio_available && attr->ctpio ) {
     *vi_flags |= EF_VI_TX_CTPIO;
-    if( ctpio_mode < 0 )
+    if( ctpio_mode == CTPIO_MODE_SF_NP )
       *vi_flags |= EF_VI_TX_CTPIO_NO_POISON;
 
     if( attr->ctpio_max_frame_len > 0 )
@@ -545,7 +545,7 @@ static int zf_stack_init_nic_capabilities(struct zf_stack* st, int nicno)
 int zf_stack_init_nic_resources(struct zf_stack_impl* sti,
                                 struct zf_attr* attr, int nicno,
                                 int ifindex, zf_if_info* if_cplane_info,
-                                unsigned vi_flags, unsigned ctpio_mode)
+                                unsigned vi_flags, int ctpio_mode)
 {
   zf_stack* st = &sti->st;
   struct zf_stack_nic* st_nic = &st->nic[nicno];
@@ -826,7 +826,7 @@ int zf_stack_alloc(struct zf_attr* attr, struct zf_stack** stack_out)
   if( attr->tx_timestamping )
     vi_flags |= EF_VI_TX_TIMESTAMPS;
 
-  unsigned ctpio_mode;
+  int ctpio_mode;
   rc = zf_stack_init_ctpio_stack_config(sti, attr, &ctpio_mode);
   if( rc < 0 )
     goto fail2;


### PR DESCRIPTION
Since `ctpio_mode` can be <0, using a signed int is more appropriate. (https://github.com/Xilinx-CNS/tcpdirect/blob/tcpdirect-9.0.0/src/lib/zf/private/stack_alloc.c#L52-L54)

We also decided that there is no obvious reason for the no-poison flag to be set in the event that `ctpio_mode < 0`. My assumption is that there was an earlier decision that any future 'no-poisoning' CTPIO modes would also have negative values like `CTPIO_MODE_SF_NP=-1`.

Another solution would be to use an enum but I do not see examples of this being used elsewhere in this codebase. This solution is the least disruptive imo.

As a test, I created a `sf-np` VI and then a `ct` VI (on same interface) and strated tx'mitting with the `ct` VI.
- Base v8_1: saw `rx_bad` accumulate on remote end.
- v8_1 + this patch: no poisoned frames hit the wire.