### PR TITLE
ON-16275: add zfmultizock_bond to slow/unreliable test list

### DIFF
--- a/src/tests/zf_unit/Makefile.inc
+++ b/src/tests/zf_unit/Makefile.inc
@@ -38,7 +38,7 @@ UT_SLOW := zf_superbuf_fallback zf_superbuf_stack_destroy zf_superbuf_locality \
            zfmultizock_bond
 
 # List of tests to skip unless ZF_RUN_UNSTABLE_TESTS=1 (defaults to 0)
-UT_UNSTABLE := zftimestamping $(UT_SCRIPTS)
+UT_UNSTABLE := zftimestamping zfbonding_lacp $(UT_SCRIPTS)
 
 # sort is required to remove duplicates
 UT_ALL := $(sort \

--- a/src/tests/zf_unit/Makefile.inc
+++ b/src/tests/zf_unit/Makefile.inc
@@ -31,9 +31,11 @@ UT_SCRIPTS := zfudppingpong.sh zf_tcp_sanity.sh packetdrill.sh zfsend.sh zfudptt
 # NOTE: Some tests are not actually slow, but rather unstable on slow machines:
 # - `zfovl`
 # - `zfquiesce_waittw`
+# - `zfmultizock_bond`
 UT_SLOW := zf_superbuf_fallback zf_superbuf_stack_destroy zf_superbuf_locality \
            zf_superbuf_n_sleep zf_superbuf_sleepy_stacks zftcptimeouts \
-           zfreactorloop zfstackfree zfrxtable zftcprx zfovl zfquiesce_waittw
+           zfreactorloop zfstackfree zfrxtable zftcprx zfovl zfquiesce_waittw \
+           zfmultizock_bond
 
 # List of tests to skip unless ZF_RUN_UNSTABLE_TESTS=1 (defaults to 0)
 UT_UNSTABLE := zftimestamping $(UT_SCRIPTS)


### PR DESCRIPTION
I had this fail in one of my [GHA runs](https://github.com/Xilinx-CNS/onload_internal/actions/runs/12885919438), where this is typically consistent elsewhere.

### Testing Done
- Built/ran unit tests manually
- [GHA still happy](https://github.com/jfeather-amd/tcpdirect/actions/runs/12889995090/job/35938542864) (and still running this from tcpdirect)