### PR TITLE
ON-16327: Improving RTT estimation for delegated sends

### DIFF
--- a/src/lib/zf/zf_ds.c
+++ b/src/lib/zf/zf_ds.c
@@ -166,10 +166,11 @@ int zf_delegated_send_complete(struct zft* ts, const struct iovec* iov,
     already_acked = 0;
 
     /* Queue remaining packets on send queue */
+    uint32_t current_lbb = pcb->snd_lbb;
     rc = tcp_queue_sent_segments(tcp, &pcb->sendq, &iov_temp, &pcb->snd_lbb);
     if( ZF_UNLIKELY(rc < 0) )
       goto out;
-    tcp_output_timers_common(zf_stack_from_zocket(tcp), tcp, pcb->snd_lbb);
+    tcp_output_timers_common(zf_stack_from_zocket(tcp), tcp, current_lbb);
 
     unsigned snd_buf_consumed = pcb->mss * rc;
     if( snd_buf_consumed > pcb->snd_buf )


### PR DESCRIPTION
rtseq is not properly initialized for delegated sends.

In zf_delegated_send_complete(...), rtseq is initialized on line 172

[https://github.com/Xilinx-CNS/tcpdirect/blob/14d93228f700fad32ea7fa93f88d79d59d7748ad/src/lib/zf/zf_ds.c#L172]
by calling tcp_output_timers_common() with seq == snd_lbb.

snd_lbb is updated right before this call (on line L169). snd_lbb is the “next sequence buffer to be buffered”.

Assume a delegated send 1 has a  seqnum range from B (inclusive) to E (exclusive), the snd_lbb is B before line 169 and E after line 169 so rtseq will be set to E in the call to tcp_output_timers_common().

When the segment 1 is acked, tcp_calculate_rtt_est() is called but `TCP_SEQ_LT(pcb->rtseq, ackno)` is false. Another segment 2 starting with seqnum E  will need to be sent for the RTT to be updated and the RTT estimate will include the “quiet” time between sending segment 1 and 2 and therefore can be overstated by a large amount

Compare the other calls to tcp_output_timers_common() in tcp_out.c:

tcp_output_timers_common(stack, tcp, ntohl(hdr->seq));
tcp_output_timers_common(stack, tcp, tcp_seg_seq(seg));

**Reproducer case:**

The issue can be reproduced using our in-house test apps:

_Exchange server sending multicast traffic at the lowest rate (-r 1):_

`andresa@sup-cap1:/usr/local/src/onload-9.0.0.39/build/gnu_x86_64/tests/trade_sim$ ./exchange enp129s0f0 -i 2 -n 2 -r 1 -s
`

Trader TCP Direct DS efvi app (current bad state): 

```
andresa@sup-cap2:~/git/tcpdirect$ ZF_ATTR="log_level=0x80" ./build/gnu_x86_64-zf-devel/bin/trade_sim/static/trader_tcpdirect_ds_efvi -d -s 100 enp129s0f0 192.168.5.2 &>log_delegated_send_incorrect.txt
andresa@sup-cap2:~/git/tcpdirect$ cat log_delegated_send_incorrect.txt| grep  -e sa                      
enp129s0f0/138  1000 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1000 seq=2434393844 sa=8 sv=2
enp129s0f0/138  1044 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1022 seq=2434393953 sa=29 sv=23
enp129s0f0/138  1089 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1066 seq=2434394153 sa=49 sv=38
andresa@sup-cap2:~/git/tcpdirect$
```
Note sa and sv which increases with higher number of hearbeats as the customer observes. 

Also, observe that with the current (bad) code the regular send works OK - as expected:

**Trader Regular Send App** 

```
andresa@sup-cap2:~/git/tcpdirect$ ZF_ATTR="log_level=0x80" ./build/gnu_x86_64-zf-devel/bin/trade_sim/static/trader_tcpdirect_ds_efvi -s 100 enp129s0f0 192.168.5.2 &>log_regular_send_correct_old_code.txt
andresa@sup-cap2:~/git/tcpdirect$ cat log_regular_send_correct_old_code.txt| grep  -e sa                 
enp129s0f0/138  1000 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1000 seq=3867133740 sa=8 sv=2
enp129s0f0/138  1022 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1022 seq=3867133749 sa=8 sv=2
enp129s0f0/138  1044 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1044 seq=3867133849 sa=8 sv=2
enp129s0f0/138  1066 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1066 seq=3867133949 sa=8 sv=2
enp129s0f0/138  1089 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1089 seq=3867134049 sa=8 sv=2

```
Observe it produces the desired result, ie, constant RTT for each of the spaced out TCP packets.


### FIX 

Trader TCP Direct DS efvi app (with the fix):

Using Delegated Sends (-d): 

```
andresa@sup-cap2:~/git/tcpdirect$ ZF_ATTR="log_level=0x80" ./build/gnu_x86_64-zf-devel/bin/trade_sim/static/trader_tcpdirect_ds_efvi -d -s 100 enp129s0f0 192.168.5.2 &>log_delegated_send_correct.txt
andresa@sup-cap2:~/git/tcpdirect$ cat log_delegated_send_correct.txt| grep  -e sa                     
enp129s0f0/138  1000 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1000 seq=2768039698 sa=8 sv=2
enp129s0f0/138  1022 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1022 seq=2768039707 sa=8 sv=2
enp129s0f0/138  1044 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1044 seq=2768039807 sa=8 sv=2
enp129s0f0/138  1066 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1066 seq=2768039907 sa=8 sv=2
enp129s0f0/138  1089 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1089 seq=2768040007 sa=8 sv=2
```

Using Regular Sends:  

```
andresa@sup-cap2:~/git/tcpdirect$ ZF_ATTR="log_level=0x80" ./build/gnu_x86_64-zf-devel/bin/trade_sim/static/trader_tcpdirect_ds_efvi -s 100 enp129s0f0 192.168.5.2 &>log_regular_send_correct.txt
andresa@sup-cap2:~/git/tcpdirect$ cat log_regular_send_correct.txt| grep  -e sa                       
enp129s0f0/138  1000 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1000 seq=3309402769 sa=8 sv=2
enp129s0f0/138  1022 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1022 seq=3309402778 sa=8 sv=2
enp129s0f0/138  1044 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1044 seq=3309402878 sa=8 sv=2
enp129s0f0/138  1066 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1066 seq=3309402978 sa=8 sv=2
enp129s0f0/138  1089 | TCP#00 | tcp_calculate_rtt_est: rtt: est=1089 seq=3309403078 sa=8 sv=2
```