### PR TITLE
ON-14783: Use additional NIC flags for X3522

### DIFF
--- a/src/include/zf_internal/private/zf_stack_def.h
+++ b/src/include/zf_internal/private/zf_stack_def.h
@@ -181,6 +181,8 @@ struct zf_stack {
 #define ZF_RES_NIC_FLAG_VLAN_FILTERS 0x1
 #define ZF_RES_NIC_FLAG_RX_LL        0x2
 #define ZF_RES_NIC_FLAG_TX_LL        0x4
+#define ZF_RES_NIC_FLAG_SHARED_RXQ   0x8
+#define ZF_RES_NIC_FLAG_CTPIO_ONLY   0x10
 
 #include <onload/version.h>
 #define ZF_VERSION_LENGTH_MAX OO_VER_STR_LEN


### PR DESCRIPTION
Running with Warnings enabled on X3 you get output warning that the NIC is not running low-latency firmware. 

This commit simply suppresses the warning on X3 NICs.

Without commit on X3522:
```
ZF_ATTR="log_level=0x2;interface=ens1f0np0" ./zfsink 224.1.1.1:9001
  1000 | Interface ens1f0np0 is not in low latency mode.
  1000 | Low latency mode is recommended for best latency with TCPDirect.
  1000 | PIO not supported by efct interface but pio=3. Not attempting to allocate PIO buffer.
Polling reactor
```

With commit on X3522:
```
ZF_ATTR="log_level=0x2;interface=ens1f0np0" ./zfsink 224.1.1.1:9001
  1000 | PIO not supported by efct interface but pio=3. Not attempting to allocate PIO buffer.
Polling reactor
```
With Commit on X2522 running full-feature firmware:
```
ZF_ATTR="log_level=0x2;interface=enp131s0f0" ./zfsink 224.1.1.1:9001
  1000 | Interface enp131s0f0 is not in low latency mode.
  1000 | Low latency mode is recommended for best latency with TCPDirect.
Polling reactor
```

With commit on X2522 running ultra-low-latency firmware:
```
ZF_ATTR="log_level=0x2;interface=enp131s0f0" ./zfsink 224.1.1.1:^C01
sudo ip l set enp129s0f0 up
ZF_ATTR="log_level=0x2;interface=enp129s0f0" ./zfsink 224.1.1.1:9001
Polling reactor
```


