### PR TITLE
ON-16341: force 2MB huge page allocation to run on 1GB default systems

### DIFF
--- a/src/lib/zf/pool.c
+++ b/src/lib/zf/pool.c
@@ -13,6 +13,7 @@
 
 #include <errno.h>
 #include <sys/mman.h>
+#include <linux/mman.h>
 
 #ifndef MAP_HUGETLB
 #define MAP_HUGETLB 0x40000u
@@ -84,7 +85,7 @@ int zf_pool_alloc(struct zf_pool_res* pi, struct zf_pool* pool,
    * to continue to use them as DMA buffers. */
   pool->pkt_bufs =
     (char*) zf_hal_mmap(NULL, alloc_size, PROT_READ | PROT_WRITE,
-                        MAP_ANONYMOUS | MAP_SHARED | MAP_HUGETLB, -1, 0);
+                        MAP_ANONYMOUS | MAP_SHARED | MAP_HUGETLB | MAP_HUGE_2MB, -1, 0);
   pi->pkt_bufs_mmap_len = alloc_size;
 
   /* Huge pages only */

--- a/src/lib/zf/stack.c
+++ b/src/lib/zf/stack.c
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include <net/if.h>
+#include <linux/mman.h>
 
 #include <ci/efhw/mc_driver_pcol.h>
 
@@ -36,7 +37,7 @@
 
 void* __alloc_huge(size_t size)
 {
-  unsigned mmap_flags = MAP_ANONYMOUS | MAP_PRIVATE | MAP_HUGETLB;
+  unsigned mmap_flags = MAP_ANONYMOUS | MAP_PRIVATE | MAP_HUGETLB | MAP_HUGE_2MB;
   auto ptr = (char*) mmap(NULL, size, PROT_READ | PROT_WRITE, mmap_flags, -1, 0);
   if( ptr == MAP_FAILED )
     return NULL;


### PR DESCRIPTION
Allocated 2MB huge pages and 1GB huge pages remains zero. System default set via kernel command line to be 1G.

Before:
```
[server01:tcpdirect]$ ZF_ATTR="interface=eth0" ./build/bin/zf_apps/static/zfsink -r 192.1.2.3:25000
ERROR: main: ZF_TRY(zfur_addr_bind(ur, ai_local->ai_addr, ai_local->ai_addrlen, NULL, 0, 0)) failed
ERROR: at src/tests/zf_apps//zfsink.c:365
ERROR: rc=-28 (No space left on device) errno=28
Aborted (core dumped)
```

After
```
[server01:tcpdirect]$ ZF_ATTR="interface=eth0" ./build/bin/zf_apps/static/zfsink -r 192.1.2.3:25000
# pkt-rate  bandwidth(Mbps)      total-pkts
         0                0                0
^C
```