### PR TITLE
ON-13283: allow application to register callback for NIC reset

### DIFF
--- a/src/include/zf/zf_stack.h
+++ b/src/include/zf/zf_stack.h
@@ -167,5 +167,16 @@ enum zf_stack_feature {
 */
 ZF_LIBENTRY int zf_stack_query_feature(struct zf_stack* stack, enum zf_stack_feature feature);
 
+/*! \brief Set a function callback for when a reset occurs on a NIC.
+**
+** \param stack     A pointer to the stack to set the callback for
+** \param func      Function to be called on reset
+** \param arg       Argument to be passed to callback
+**
+** \return 0 on success
+*/
+ZF_LIBENTRY
+int zf_set_reset_callback(struct zf_stack* st, void (*func)(void*), void* arg);
+
 #endif /* __ZF_STACK_H__ */
 /** @} */

--- a/src/include/zf_internal/private/zf_stack_def.h
+++ b/src/include/zf_internal/private/zf_stack_def.h
@@ -305,6 +305,9 @@ struct zf_stack_impl {
   /* Onload driver handle for shared-memory purposes. */
   int onload_dh;
 
+  void (*reset_callback)(void*);
+  void* reset_callback_arg;
+
   /* Must be last field */
   zf_allocator alloc;
 };

--- a/src/lib/zf/private/reactor.c
+++ b/src/lib/zf/private/reactor.c
@@ -186,6 +186,13 @@ efct_pkt_memcpy(void* dst, const void* src, size_t n)
 }
 
 
+ZF_COLD static void
+zf_reactor_handle_reset_event(struct zf_stack* st)
+{
+  const struct zf_stack_impl* sti = ZF_CONTAINER(struct zf_stack_impl, st, st);
+  sti->reset_callback(sti->reset_callback_arg);
+}
+
 /* returns 1 if something interesting has happened */
 ZF_HOT int
 zf_reactor_process_event(struct zf_stack* st, int nic, ef_vi* vi, ef_event* ev)
@@ -255,6 +262,9 @@ zf_reactor_process_event(struct zf_stack* st, int nic, ef_vi* vi, ef_event* ev)
     break;
   case EF_EVENT_TYPE_RX_REF_DISCARD:
     zf_reactor_handle_rx_ref_discard(st, nic, vi, ev);
+    break;
+  case EF_EVENT_TYPE_RESET:
+    zf_reactor_handle_reset_event(st);
     break;
   default:
     zf_log_stack_err(st, "ERROR: unexpected event type=%d\n",

--- a/src/lib/zf/stack.c
+++ b/src/lib/zf/stack.c
@@ -487,3 +487,11 @@ zf_stack_query_feature(struct zf_stack* stack, enum zf_stack_feature feature)
   return -ENOENT;
 
 }
+
+int zf_set_reset_callback(struct zf_stack* st, void (*func)(void*), void* arg)
+{
+  struct zf_stack_impl* sti = ZF_CONTAINER(struct zf_stack_impl, st, st);
+  sti->reset_callback = func;
+  sti->reset_callback_arg = arg;
+  return 0;
+}

--- a/src/tests/zf_apps/zfsink.c
+++ b/src/tests/zf_apps/zfsink.c
@@ -281,6 +281,12 @@ static void* monitor_fn(void* arg)
 }
 
 
+static void callback(void* arg)
+{
+  printf("Reset callback on %s\n", (char*)arg);
+}
+
+
 int main(int argc, char* argv[])
 {
   pthread_t thread_id;
@@ -372,6 +378,10 @@ int main(int argc, char* argv[])
   pthread_mutex_init(&printf_mutex, NULL);
   res.n_rx_bytes = 0;
   res.n_rx_pkts = 0;
+
+  char* intf;
+  zf_attr_get_str(attr, "interface", &intf);
+  zf_set_reset_callback(stack, &callback, intf);
 
   if( ! cfg_quiet )
     ZF_TRY(pthread_create(&thread_id, NULL, monitor_fn, NULL) == 0);


### PR DESCRIPTION
Add ability for an application to register a callback if the NIC used by the stack is reset. User is able to specify an argument to be passed to it. This allows the application to take action in that scenario.

Updated `efsink` to use the callback and show the interface name being passed through to the function.