### PR TITLE
ON-16450: Fix ZF_DEVEL=1 builds

### DIFF
--- a/src/tests/zf_unit/Makefile.inc
+++ b/src/tests/zf_unit/Makefile.inc
@@ -85,8 +85,6 @@ $(UT_BINS): $(UT_BINDIR)/%: $(OBJ_CURRENT)/%.o
 $(UT_BINS): $(OBJ_CURRENT)/../tap/tap.o
 $(UT_BINS): $(ZF_STATIC_LIB) $(CIUL_LIB)
 
-LDFLAGS += -lciul1
-
 $(UT_BINS):
 	@mkdir -p $(dir $@)
 	$(CLINK) $^ -lm -lpthread -lrt -ldl -lstdc++ -o $@


### PR DESCRIPTION
Fix the following build-time error when both ZF and Onload are built from git-tree:
```
$ ZF_DEVEL=1 ONLOAD_TREE=... make
...
/usr/bin/ld: cannot find -lciul1
collect2: error: ld returned 1 exit status
```
A problem here was src/tests/zf_unit/Makefile.inc setting `LD_FLAGS` and these being passed to src/tests/trade_sim/Makefile indirectly via the top-level Makefile. It is only a problem when Onload is not installed in the OS.

---

Testing with `onload-9.0`:
1. In-tree Onload with in-tree ZF, i.e. `ONLOAD_TREE=~/lab/onload_internal make` (Pass)
2. The same as (1) with `ZF_DEVEL=1`, i.e. `ZF_DEVEL=1 ONLOAD_TREE=~/lab/onload_internal make` (Pass)
3. Installed Onload with `./scripts/zf_make_official_srpm` and `rpmbuild --rebuild ~/rpmbuild/SRPMS/tcpdirect-8ee7d8ffec6cced9b9ee898871f9f52d35b52eac-1.src.rpm` (Pass)
4. Also, when installed, `make` in both directories in `/usr/share/doc/tcpdirect/examples/` (Pass)