### PR TITLE
ON-16435: Replace arch checks with nic capabilies

### DIFF
--- a/src/include/zf_internal/private/zf_stack_def.h
+++ b/src/include/zf_internal/private/zf_stack_def.h
@@ -341,4 +341,9 @@ static inline const ef_vi* zf_stack_nic_tx_vi(const zf_stack* st, int nicno) {
 static inline bool zf_stack_nic_has_tx_vi(const zf_stack* st, int nicno) {
   return st->nic[nicno].tx_vi.inited; }
 
+static inline unsigned* zf_stack_res_nic_flags(zf_stack* st, int nicno) {
+  struct zf_stack_impl* sti = ZF_CONTAINER(struct zf_stack_impl, st, st);
+  return &sti->nic[nicno].flags;
+}
+
 #endif /* __ZF_INTERNAL_STACK_DEF_H__ */

--- a/src/include/zf_internal/private/zf_stack_def.h
+++ b/src/include/zf_internal/private/zf_stack_def.h
@@ -181,6 +181,9 @@ struct zf_stack {
 #define ZF_RES_NIC_FLAG_VLAN_FILTERS 0x1
 #define ZF_RES_NIC_FLAG_RX_LL        0x2
 #define ZF_RES_NIC_FLAG_TX_LL        0x4
+#define ZF_RES_NIC_FLAG_RX_REF       0x8
+#define ZF_RES_NIC_FLAG_CTPIO_ONLY   0x10
+#define ZF_RES_NIC_FLAG_PIO          0x20
 
 #include <onload/version.h>
 #define ZF_VERSION_LENGTH_MAX OO_VER_STR_LEN

--- a/src/include/zf_internal/tx_send.h
+++ b/src/include/zf_internal/tx_send.h
@@ -288,6 +288,7 @@ zf_send(struct zf_tx* restrict tx,
     }
   }
   zf_assert_nequal(vi->nic_type.arch, EF_VI_ARCH_EFCT);
+  zf_assert_nequal(vi->nic_type.arch, EF_VI_ARCH_EF10CT);
   /* Strictly speaking, we should call ef_vi_transmit_ctpio_fallback()
    * to post a CTPIO fallback descriptor. However, that entry point is
    * actually identical to this one, and this code path is also used

--- a/src/include/zf_internal/tx_send.h
+++ b/src/include/zf_internal/tx_send.h
@@ -164,7 +164,7 @@ zf_send(struct zf_tx* restrict tx,
     return -EAGAIN;
 #endif
 
-  if( vi->nic_type.arch == EF_VI_ARCH_EFCT ) {
+  if( *zf_stack_res_nic_flags(st, nicno) & ZF_RES_NIC_FLAG_CTPIO_ONLY ) {
     /* FIXME get X3 overhead sorted properly */
     if(ZF_UNLIKELY( ef_vi_transmit_space_bytes(vi) < (int)tot_len + 128 )) {
       if( st->flags & ZF_STACK_FLAG_TRANSMIT_WARM_ENABLED )
@@ -207,7 +207,7 @@ zf_send(struct zf_tx* restrict tx,
       !ctpio_is_allowed(st_nic, tot_len) &&
       pio_is_available(st_nic) &&
       tot_len <= max_pio_len(st_nic) && iov_cnt <= 2 ) {
-    zf_assert_nequal(vi->nic_type.arch, EF_VI_ARCH_EFCT);
+    zf_assert(*zf_stack_res_nic_flags(st, nicno) & ZF_RES_NIC_FLAG_PIO);
     int pio_buf_no = st_nic->pio.busy & 1;
     int orig_pio_ofs = pio_buf_no ? max_pio_len(st_nic) : 0;
     rc = ef10_ef_vi_transmitv_copy_pio(vi, orig_pio_ofs, iov, iov_cnt, 1);

--- a/src/include/zf_internal/zf_stack.h
+++ b/src/include/zf_internal/zf_stack.h
@@ -71,7 +71,7 @@ ZF_HOT static inline void zf_stack_refill_rx_ring(struct zf_stack* st,
                                                   int nic, unsigned max_count)
 {
   ef_vi* vi = &st->nic[nic].vi;
-  if( vi->nic_type.arch == EF_VI_ARCH_EFCT )
+  if( *zf_stack_res_nic_flags(st, nic) & ZF_RES_NIC_FLAG_RX_REF )
     return;
   unsigned space = ef_vi_receive_space(vi);
   if( space < st->nic[nic].rx_ring_refill_batch_size )

--- a/src/lib/zf/private/stack_fast.c
+++ b/src/lib/zf/private/stack_fast.c
@@ -90,7 +90,7 @@ zf_stack_handle_rx(struct zf_stack* st, int nic, const char* iov_base,
   if( rx_prefix_len ){
     ef_vi* vi = &(st->nic[nic].vi);
 
-    if( vi->nic_type.arch != EF_VI_ARCH_EFCT ) {
+    if( *zf_stack_res_nic_flags(st, nic) & ZF_RES_NIC_FLAG_RX_REF ) {
       ef_eventq_state* evqs = &(vi->ep_state->evq);
 
       /* To overcome the restrictions that come with using ef_vi's timestamping

--- a/src/lib/zf/rx.c
+++ b/src/lib/zf/rx.c
@@ -269,7 +269,7 @@ zfrr_hw_filter_init_vlan(struct zf_stack* st, int nicno, int proto,
   struct zf_stack_impl* sti = ZF_CONTAINER(struct zf_stack_impl, st, st);
 
   if( proto == IPPROTO_UDP && is_multicast(laddr) &&
-      sti->nic[nicno].flags & ZF_RES_NIC_FLAG_VLAN_FILTERS &&
+      *zf_stack_res_nic_flags(st, nicno) & ZF_RES_NIC_FLAG_VLAN_FILTERS &&
       sti->sti_vlan_id != ZF_NO_VLAN ) {
     ef_filter_spec_set_vlan(spec, sti->sti_vlan_id);
   }

--- a/src/lib/zf/stack.c
+++ b/src/lib/zf/stack.c
@@ -242,12 +242,13 @@ int zf_stack_free(struct zf_stack* stack)
       unsigned tx_packets = ef_vi_transmit_fill_level(zf_stack_nic_tx_vi(stack, nicno)) - pkts_in_pio;
       unsigned rx_packets = ef_vi_receive_fill_level(&stack->nic[nicno].vi);
 
-      /* For X3 ef_vi_transmit_fill_level and PIO states are bogus */
-      if( zf_stack_nic_tx_vi(stack, nicno)->nic_type.arch != EF_VI_ARCH_EFCT )
+      /* For CTPIO only boards, ef_vi_transmit_fill_level and PIO states are
+       * bogus */
+      if( !(*zf_stack_res_nic_flags(stack, nicno) &
+            ZF_RES_NIC_FLAG_CTPIO_ONLY) ) {
         pkts_accounted += tx_packets;
-
-      if( stack->nic[nicno].vi.nic_type.arch != EF_VI_ARCH_EFCT )
         pkts_accounted += rx_packets;
+      }
 
       zf_log_stack_trace(stack,
                          "%s: VI %d: busy pkts=%d vs %d: rx_hw=%d tx_hw=%d "

--- a/src/lib/zf/tx_warm.c
+++ b/src/lib/zf/tx_warm.c
@@ -16,7 +16,8 @@ int enable_tx_warm(struct zf_tx* tx, zf_tx_warm_state* state)
   zf_log_stack_trace(st, "%s: TX warm enabled\n", __func__);
   char* ctpio_warm_buf = NULL;
   state->ctpio_warm_buf_id = PKT_INVALID;
-  if( vi->vi_flags & EF_VI_TX_CTPIO && vi->nic_type.arch != EF_VI_ARCH_EFCT ) {
+  if( vi->vi_flags & EF_VI_TX_CTPIO && vi->nic_type.arch != EF_VI_ARCH_EFCT
+      && vi->nic_type.arch != EF_VI_ARCH_EF10CT ) {
     int rc = zft_alloc_pkt(&st->pool, &state->ctpio_warm_buf_id);
     if( rc < 0 )
       return rc;

--- a/src/lib/zf/udp_tx.c
+++ b/src/lib/zf/udp_tx.c
@@ -194,7 +194,7 @@ try_clean_tx_completions(struct zf_udp_tx* udp_tx)
   int iterations = 0;
 #endif
 
-  if( vi->nic_type.arch != EF_VI_ARCH_EFCT )
+  if( *zf_stack_res_nic_flags(st, nicno) &  ZF_RES_NIC_FLAG_CTPIO_ONLY )
     return false;
   for( ; ; ) {
     ef_event ev;

--- a/src/lib/zf/zf_stackdump.c
+++ b/src/lib/zf/zf_stackdump.c
@@ -96,7 +96,8 @@ void dump_nic(SkewPointer<zf_stack_impl> stimpl, int index)
     return;
 
   zf_dump("nic%d: vi=%d vi_flags=%x nic_flags=%x intf=%s index=%d hw=%u%c%u\n",
-          index, ef_vi_instance(vi), ef_vi_flags(vi), stimpl->nic[index].flags,
+          index, ef_vi_instance(vi), ef_vi_flags(vi),
+          *zf_stack_res_nic_flags(&stimpl->st, index),
           stimpl->nic[index].if_name, stimpl->nic[index].ifindex,
           vi->nic_type.arch, vi->nic_type.variant, vi->nic_type.revision);
 #if 0


### PR DESCRIPTION
```
ON-16435: Add getter for nic res flags

This makes it easier to change whether these flags are in zf_stack or
zf_stack_impl. Keeping them in the latter struct may have impact on
cache hit rate in the hotpath where these flags may be queried.
```

```
ON-16435: Add new ZF_RES_NIC_FLAGS and use them over arch checks
```

```
ON-16435: Add ef10ct arch check where capabilitiy is unclear
```

The final commit is probably not what we want but I am at a bit of a loss for what capabilities should be used in those cases. I therefore added ef10ct arch checks. Opening this as a draft because of this.

### Testing C-Model

`zfsink`
```
ZF_ATTR="interface=enp1s0f0" EF_VI_RXQ_SIZE=4096 EF_VI_PD_FLAGS=llct ./zfsink 192.168.135.105:2000
efct_design_parameters: unsupported rx_superbuf_bytes, 0 != 1048576
efct_design_parameters: rx_superbuf_bytes = 0 = 0, treating it as it were the standard value
# pkt-rate  bandwidth(Mbps)      total-pkts
         0                0                0
         0                0                0
         0                0                0
        25                0               25
       398                0              423
---- Some time later (packet rate on C-Model is low) ----
       400                0             5120
       400                0             5520
       400                0             5920
        80                0             6000
         0                0             6000
```

`zfsend`

```
ZF_ATTR="interface=enp1s0f0" EF_VI_PD_FLAGS=llct ./zfsend -u -i 5000 192.168.135.105:2000 230.1.2.3:2000
```

All packets received at the other end. I had to modify zfsend to sleep 1000us between sends (not sure of the sends are batched) because otherwise the sends would fail and zfsend would hit an assertion. This is fine because the C-Model cannot keep up with the sends.