### PR TITLE
ON-16435: Add arch checks for ef10ct

### DIFF
--- a/src/include/zf_internal/tx_send.h
+++ b/src/include/zf_internal/tx_send.h
@@ -164,7 +164,8 @@ zf_send(struct zf_tx* restrict tx,
     return -EAGAIN;
 #endif
 
-  if( vi->nic_type.arch == EF_VI_ARCH_EFCT ) {
+  if( vi->nic_type.arch == EF_VI_ARCH_EFCT ||
+      vi->nic_type.arch == EF_VI_ARCH_EF10CT) {
     /* FIXME get X3 overhead sorted properly */
     if(ZF_UNLIKELY( ef_vi_transmit_space_bytes(vi) < (int)tot_len + 128 )) {
       if( st->flags & ZF_STACK_FLAG_TRANSMIT_WARM_ENABLED )
@@ -208,6 +209,7 @@ zf_send(struct zf_tx* restrict tx,
       pio_is_available(st_nic) &&
       tot_len <= max_pio_len(st_nic) && iov_cnt <= 2 ) {
     zf_assert_nequal(vi->nic_type.arch, EF_VI_ARCH_EFCT);
+    zf_assert_nequal(vi->nic_type.arch, EF_VI_ARCH_EF10CT);
     int pio_buf_no = st_nic->pio.busy & 1;
     int orig_pio_ofs = pio_buf_no ? max_pio_len(st_nic) : 0;
     rc = ef10_ef_vi_transmitv_copy_pio(vi, orig_pio_ofs, iov, iov_cnt, 1);
@@ -288,6 +290,7 @@ zf_send(struct zf_tx* restrict tx,
     }
   }
   zf_assert_nequal(vi->nic_type.arch, EF_VI_ARCH_EFCT);
+  zf_assert_nequal(vi->nic_type.arch, EF_VI_ARCH_EF10CT);
   /* Strictly speaking, we should call ef_vi_transmit_ctpio_fallback()
    * to post a CTPIO fallback descriptor. However, that entry point is
    * actually identical to this one, and this code path is also used

--- a/src/include/zf_internal/zf_stack.h
+++ b/src/include/zf_internal/zf_stack.h
@@ -71,7 +71,8 @@ ZF_HOT static inline void zf_stack_refill_rx_ring(struct zf_stack* st,
                                                   int nic, unsigned max_count)
 {
   ef_vi* vi = &st->nic[nic].vi;
-  if( vi->nic_type.arch == EF_VI_ARCH_EFCT )
+  if( vi->nic_type.arch == EF_VI_ARCH_EFCT ||
+      vi->nic_type.arch == EF_VI_ARCH_EF10CT)
     return;
   unsigned space = ef_vi_receive_space(vi);
   if( space < st->nic[nic].rx_ring_refill_batch_size )

--- a/src/lib/zf/private/reactor.c
+++ b/src/lib/zf/private/reactor.c
@@ -508,7 +508,8 @@ __zf_reactor_perform(struct zf_stack* st, unsigned spin_cnt)
            * from the future in the next RX buffer. */
           pkt_id next_packet_id = 0;
           char* next_packet;
-          bool is_efct = vi->nic_type.arch == EF_VI_ARCH_EFCT;
+          bool is_efct = vi->nic_type.arch == EF_VI_ARCH_EFCT ||
+                         vi->nic_type.arch == EF_VI_ARCH_EF10CT;
           bool packet_present;
 
           if( is_efct ) {
@@ -644,6 +645,7 @@ zf_reactor_purge_event(struct zf_stack* st, int nic, ef_vi* vi, ef_event* ev)
     zf_assert_nequal(EF_EVENT_RX_SOP(*ev), 0);
     zf_assert_equal(EF_EVENT_RX_CONT(*ev), 0);
     zf_assert_nequal(vi->nic_type.arch, EF_VI_ARCH_EFCT);
+    zf_assert_nequal(vi->nic_type.arch, EF_VI_ARCH_EF10CT);
     zf_pool_free_pkt(&st->pool, EF_EVENT_RX_RQ_ID(*ev));
     zf_log_event_trace(st, "%s: purged event %x\n", __FUNCTION__,
                        EF_EVENT_RX_RQ_ID(*ev));
@@ -652,7 +654,6 @@ zf_reactor_purge_event(struct zf_stack* st, int nic, ef_vi* vi, ef_event* ev)
     zf_reactor_handle_tx_event(st, nic, vi, ev);
     return ZF_REACTOR_PURGE_STATUS_TX;
   case EF_EVENT_TYPE_RX_REF:
-    zf_assert_equal(vi->nic_type.arch, EF_VI_ARCH_EFCT);
     efct_vi_rxpkt_release(vi, ev->rx_ref.pkt_id);
     zf_log_event_trace(st, "%s: purged event %x\n", __FUNCTION__, ev->rx_ref.pkt_id);
     return ZF_REACTOR_PURGE_STATUS_RX;

--- a/src/lib/zf/private/stack_alloc.c
+++ b/src/lib/zf/private/stack_alloc.c
@@ -243,7 +243,8 @@ static int zf_stack_init_pio(struct zf_stack_impl* sti, struct zf_attr* attr,
   struct zf_stack_res_nic* sti_nic = &sti->nic[nicno];
   ef_vi* vi = zf_stack_nic_tx_vi(st_nic);
 
-  if( st_nic->vi.nic_type.arch == EF_VI_ARCH_EFCT &&
+  if( (st_nic->vi.nic_type.arch == EF_VI_ARCH_EFCT ||
+       st_nic->vi.nic_type.arch == EF_VI_ARCH_EF10CT) &&
       attr->pio >= PIO_MUST_USE ) {
     zf_log_stack_warn(st,
                       "PIO not supported by efct interface but pio=%d. "
@@ -638,7 +639,8 @@ int zf_stack_init_nic_resources(struct zf_stack_impl* sti,
   if ( attr->rx_ring_max != 0 ) {
     /* For EFCT, we store the timestamp in a fake prefix when copying from
      * the shared rx buffer into our own packet buffer. */
-    if( st_nic->vi.nic_type.arch == EF_VI_ARCH_EFCT )
+    if( st_nic->vi.nic_type.arch == EF_VI_ARCH_EFCT ||
+        st_nic->vi.nic_type.arch == EF_VI_ARCH_EF10CT )
       st_nic->rx_prefix_len = ES_DZ_RX_PREFIX_SIZE;
     else
       st_nic->rx_prefix_len = ef_vi_receive_prefix_len(&st_nic->vi);

--- a/src/lib/zf/private/stack_fast.c
+++ b/src/lib/zf/private/stack_fast.c
@@ -90,7 +90,8 @@ zf_stack_handle_rx(struct zf_stack* st, int nic, const char* iov_base,
   if( rx_prefix_len ){
     ef_vi* vi = &(st->nic[nic].vi);
 
-    if( vi->nic_type.arch != EF_VI_ARCH_EFCT ) {
+    if( vi->nic_type.arch != EF_VI_ARCH_EFCT &&
+        vi->nic_type.arch != EF_VI_ARCH_EF10CT ) {
       ef_eventq_state* evqs = &(vi->ep_state->evq);
 
       /* To overcome the restrictions that come with using ef_vi's timestamping

--- a/src/lib/zf/stack.c
+++ b/src/lib/zf/stack.c
@@ -243,10 +243,12 @@ int zf_stack_free(struct zf_stack* stack)
       unsigned rx_packets = ef_vi_receive_fill_level(&stack->nic[nicno].vi);
 
       /* For X3 ef_vi_transmit_fill_level and PIO states are bogus */
-      if( zf_stack_nic_tx_vi(stack, nicno)->nic_type.arch != EF_VI_ARCH_EFCT )
+      if( zf_stack_nic_tx_vi(stack, nicno)->nic_type.arch != EF_VI_ARCH_EFCT &&
+          zf_stack_nic_tx_vi(stack, nicno)->nic_type.arch != EF_VI_ARCH_EF10CT)
         pkts_accounted += tx_packets;
 
-      if( stack->nic[nicno].vi.nic_type.arch != EF_VI_ARCH_EFCT )
+      if( stack->nic[nicno].vi.nic_type.arch != EF_VI_ARCH_EFCT &&
+          stack->nic[nicno].vi.nic_type.arch != EF_VI_ARCH_EF10CT)
         pkts_accounted += rx_packets;
 
       zf_log_stack_trace(stack,

--- a/src/lib/zf/tx_warm.c
+++ b/src/lib/zf/tx_warm.c
@@ -16,7 +16,8 @@ int enable_tx_warm(struct zf_tx* tx, zf_tx_warm_state* state)
   zf_log_stack_trace(st, "%s: TX warm enabled\n", __func__);
   char* ctpio_warm_buf = NULL;
   state->ctpio_warm_buf_id = PKT_INVALID;
-  if( vi->vi_flags & EF_VI_TX_CTPIO && vi->nic_type.arch != EF_VI_ARCH_EFCT ) {
+  if( vi->vi_flags & EF_VI_TX_CTPIO && vi->nic_type.arch != EF_VI_ARCH_EFCT &&
+      vi->nic_type.arch != EF_VI_ARCH_EF10CT) {
     int rc = zft_alloc_pkt(&st->pool, &state->ctpio_warm_buf_id);
     if( rc < 0 )
       return rc;

--- a/src/lib/zf/udp_tx.c
+++ b/src/lib/zf/udp_tx.c
@@ -194,7 +194,8 @@ try_clean_tx_completions(struct zf_udp_tx* udp_tx)
   int iterations = 0;
 #endif
 
-  if( vi->nic_type.arch != EF_VI_ARCH_EFCT )
+  if( vi->nic_type.arch != EF_VI_ARCH_EFCT &&
+      vi->nic_type.arch != EF_VI_ARCH_EF10CT)
     return false;
   for( ; ; ) {
     ef_event ev;


### PR DESCRIPTION
This means the correct code paths are taken.

### Testing

Same as https://github.com/Xilinx-CNS/tcpdirect/pull/75 - traffic passes on zfsink/zfsend

zf_emu tests pass