### PR TITLE
ON-16676: Filter out debian build flags to get rid of invalid werror

### DIFF
--- a/scripts/debian-templ/rules
+++ b/scripts/debian-templ/rules
@@ -7,7 +7,10 @@
 # dpkg-buildflags sets link time optimisation by default. Because we want to
 # finish before the heat death of the universe, we disable the optimisation for
 # this package.
-export DEB_BUILD_MAINT_OPTIONS=optimize=-lto
+#
+# bug-implicit-func filters out -Werror=implicit-function-declaration
+# Revisit on evaluation of ON-16681 
+export DEB_BUILD_MAINT_OPTIONS=optimize=-lto qa=-bug-implicit-func
 
 %:
 	dh $@


### PR DESCRIPTION
This I have done on ubuntu24.04 and debian13. It is a rule that explicitly filters out the flag we are having issues with.

   qa
       Several compile-time options (detailed below) can be used to help detect problems in the  source  code  or
       build system.

       bug-implicit-func
           This    setting    (since    dpkg    1.22.3;    enabled   by   default   since   dpkg   1.22.6)   adds
           -Werror=implicit-function-declaration to CFLAGS.

Tested the build process with the rules and it seems to work okay.