### PR TITLE
ON-16400: switch zf*pingpong to use rdtscp for more accurate latency measurement

### DIFF
--- a/src/tests/zf_apps/zf_timer.h
+++ b/src/tests/zf_apps/zf_timer.h
@@ -16,8 +16,8 @@ inline uint64_t get_frc64_time_standard(void)
 }
 
 /* Return measure of free running counter, using rdtscp, which gives higher accuracy when measuring 
- * the duration of blocks of code as it can't be reordered, but has slightly higher overhead than
- * get_frc64_time_standard() */
+ * the duration of blocks of code as it can't be reordered with earlier instructions, but has 
+ * slightly higher overhead than get_frc64_time_standard() */
 inline uint64_t get_frc64_time_accurate(void)
 {
   unsigned int aux;


### PR DESCRIPTION
I'd welcome some early review of the approach here: it looks like the zf_timer.h code is only used in zf[udp/tcp]pingpong, so I've made the change there, but happy to do it otherwise (e.g. in zf[udp/tcp]pingpong themselves) if there's a preference for that.

I'd also welcome suggestions for testing that reviewers would like to see before this gets merged, and possibly help with getting it done if it involves test infrastructure like jenkins jobs I don't have access to. 