### PR TITLE
ON-15146: Enable ZF_ATTR shrub_controller for enabling tcpdirect stacks to work with a given shrub_controller

### DIFF
--- a/src/include/zf_internal/attr_tmpl.h
+++ b/src/include/zf_internal/attr_tmpl.h
@@ -346,6 +346,17 @@ ZF_ATTR(int, phys_address_mode, stable, 0, NULL,
         "\n"
         "0 - Don't enable physical addressing mode. User space sees virtual addresses \n"
         "    which are translated by hardware or in the kernel.")
+
+ZF_ATTR(int, shrub_controller, stable, -1, NULL,
+        "zf_vi",
+
+        "Enable shrub controller on this VI.  This is required to enable zf_stacks \n"
+        "to attach to a given shared controller on given x4 platforms. \n"
+        "Possible values here include -1 for default no shrub controller, \n"
+        "or a value from 0 to 9999 to connect to a particular controller. \n"
+        "TCPDirect expects the shrub controller to be spawned manually separately to \n"
+        "the application using the zf_stack.")
+
 /**********************************************************************
  * zf_pool attributes.
  */

--- a/src/include/zf_internal/private/zf_stack_def.h
+++ b/src/include/zf_internal/private/zf_stack_def.h
@@ -286,6 +286,7 @@ struct zf_stack_impl {
   int sti_udp_ttl;
   int sti_rx_datapath;
   int sti_phys_address_mode;
+  int sti_shrub_controller;
   uint64_t sti_log_level;
   
   int n_alts; /* Number of alternatives actually allocated to this VI */

--- a/src/lib/zf/zf_stackdump.c
+++ b/src/lib/zf/zf_stackdump.c
@@ -48,6 +48,7 @@ void dump_attributes(SkewPointer<zf_stack_impl> stimpl)
     ? "enterprise"
     : "express"));
   zf_dump("phys_address_mode=%d\n", stimpl->sti_phys_address_mode);
+  zf_dump("shrub_controller=%d\n", stimpl->sti_shrub_controller);
   zf_dump("pio=%d\n", stimpl->sti_pio);
   zf_dump("reactor_spin_count=%d\n", stimpl->sti_reactor_spin_count);
   zf_dump("tcp_timewait_ms=%d\n", stimpl->sti_tcp_timewait_ms);  


### PR DESCRIPTION
TESTING DONE:
On machine 1)
sudo shrub_controller -c 37 -d
In a new terminal
ZF_ATTR="interface=enp1s0f0;shrub_controller_id=37" ./build/gnu_x86_64/bin/zf_apps/static/zfsink 224.0.2.23:8080

With the above, i see the interfaces negotiate with the shrub_controller
ci Info: shrub_controller created a new server on interface with ifindex 3 buffer_count 4 hwport 5

zf_stackdump dump also shows shrub_controller_id
```
[krishd@dellr230t tcpdirect]$ sudo ./build/gnu_x86_64/bin/zf_stackdump dump
============================================================
onload version=547533a0d5 2025-09-08 master
tcpdirect version=9.1.0 23d32e4 2025-09-10 ON-15146
name=enp1s0f0/003 interface=enp1s0f0 vlan_id=65535
  pool: pkt_bufs_n=18048 free=18048
  config: tcp_timewait_ticks=666 tcp_finwait_ticks=666 ctpio_threshold=65535
  config: tcp_initial_cwnd=0 ms_per_tcp_tick=90
  alts: n_alts=0
  stats: ring_refill_nomem=0 cplane_alien_ifindex=0
         tcp_retransmits=0
  discards: discard_csum_bad=0 discard_mcast_mismatch=0
         discard_crc_bad=0 discard_trunc=0 discard_rights=0
         discard_ev_error=0 discard_other=0 discard_inner_csum_bad=0
         non_tcpudp=0
]
nic0: vi=3 vi_flags=3000000 nic_flags=1 intf=enp1s0f0 index=3 hw=5A0
  txq: pio_buf_size=0 added=0 removed=0
============================================================
UDP RX enp1s0f0/003:0
  filter: lcl=224.0.2.23:8080 rmt=0.0.0.0:0
  rx: unread=0 begin=0 process=0 end=0
  udp rx: release_n=0 q_drops=0
------------------------------------------------------------
---------------------attributes-------------------------------
tx_ring_max=512
rx_ring_max=512
tx_timestamping=0
rx_timestamping=0
ctpio=1
ctpio_mode=sf-np
rx_datapath=express
phys_address_mode=0
shrub_controller_id=37

```

If a user attempts to set the shrub_controller as -2, or 100000
[krishd@dellr230t tcpdirect]$ ZF_ATTR="interface=enp1s0f0;shrub_controller_id=10000" ./build/bin/zf_apps/static/zfsink 224.0.2.23:808
0
  1000 | Bad shrub_controller_id; value must be -1 or in range 0 to 9999
ERROR: main: ZF_TRY(zf_stack_alloc(attr, &stack)) failed
ERROR: at src/tests/zf_apps//zfsink.c:265
ERROR: rc=-22 (Invalid argument) errno=0

If a user attempts to connect to a controller that is not running.
[krishd@dellr230t tcpdirect]$ ZF_ATTR="interface=enp1s0f0;shrub_controller_id=38" ./build/bin/zf_apps/static/zfsink 224.0.2.23:8080
  1000 | Failed to allocate VI (rc = -2)
ERROR: main: ZF_TRY(zf_stack_alloc(attr, &stack)) failed
ERROR: at src/tests/zf_apps//zfsink.c:265
ERROR: rc=-2 (No such file or directory) errno=2
Aborted (core dumped)