### PR TITLE
ON-16909: Ensure EF_FILTER_FLAG_SHARED_RXQ gets passed in on x4 shrub mode

### DIFF
--- a/src/include/zf_internal/private/zf_stack_def.h
+++ b/src/include/zf_internal/private/zf_stack_def.h
@@ -122,7 +122,7 @@ struct zf_stack {
     unsigned event_occurred_carry;
   } pftf;
 
-
+  bool x4_shared_mode;
   zf_stack_flag flags;
 
   uint32_t ctpio_max_frame_len;

--- a/src/lib/zf/private/stack_alloc.c
+++ b/src/lib/zf/private/stack_alloc.c
@@ -333,6 +333,7 @@ static int zf_stack_init_shrub_controller(struct zf_stack_impl* sti,
   }
 
   *shrub_controller = attr->shrub_controller;
+  st->x4_shared_mode = attr->shrub_controller != EF_SHRUB_NO_SHRUB;
   return 0;
 }
 

--- a/src/lib/zf/rx.c
+++ b/src/lib/zf/rx.c
@@ -287,10 +287,11 @@ zfrr_hw_filter_init(struct zf_stack* st, zfrr_nic_mask nics, int proto,
   zf_assume(nics);
 
   int nic;
+  enum ef_filter_flags flags = (enum ef_filter_flags) (st->x4_shared_mode ? EF_FILTER_FLAG_SHARED_RXQ : 0 );
   for( nic = 0; nic < st->nics_n; ++nic ) {
     if( (1ull << nic) & nics ) {
       ef_filter_spec spec;
-      ef_filter_spec_init(&spec, (enum ef_filter_flags) 0);
+      ef_filter_spec_init(&spec, flags);
       zfrr_hw_filter_init_vlan(st, nic, proto, laddr, &spec);
 
       if( raddr != NULL )


### PR DESCRIPTION
For this PR please only review the last commit. It does need the preceding commit too as I needed to store in zf_stack the share mode variable.

I was debating on this whether I should store the additional shared mode as a zf_stack flag, but figure this would be neater and simpler versus taking valuable flag space.



Testing done:

Ran zfsink connecting to the same controller
ZF_ATTR="interface=enp1s0f0;shrub_controller_id=37"  ./build/gnu_x86_64/bin/zf_apps/static/zfsink 224.0
.2.23:8080
ZF_ATTR="interface=enp1s0f0;shrub_controller_id=37"  ./build/gnu_x86_64/bin/zf_apps/static/zfsink 224.0
.2.23:8080

shrub_controller:
[krishd@dellr230t ~]$ sudo shrub_controller -c 37 -d
ci Info: shrub_controller Debug Mode Enabled!
ci Info: shrub_controller created a new server on interface with ifindex 3 buffer_count 4 hwport 5
ci Info: shrub_controller found duplicate shrub_server with ifindex 3
ci Info: shrub_controller found duplicate shrub_server with ifindex 3

Before:
[krishd@dellr230t tcpdirect]$ EF_SHRUB_CONTROLLER=37 ZF_ATTR="interface=enp1s0f0" ./build/gnu_x86_64/bin/zf_apps/static/zfsink 224.0.2.23:8080
ERROR: main: ZF_TRY(zfur_addr_bind(ur, ai_local->ai_addr, ai_local->ai_addrlen, NULL, 0, 0)) failed
ERROR: at src/tests/zf_apps//zfsink.c:274
ERROR: rc=-1 (Operation not permitted) errno=1
Aborted (core dumped)

Now:
Both work fine.

More to the point with zfsink and sending traffic, i see packets being seen on both zfsink instances.