### PR TITLE
ON-16616: Minor cleanup of the github actions for tcpdirect

### DIFF
--- a/.github/workflows/perform_build.yml
+++ b/.github/workflows/perform_build.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/packetdrill-tcpdirect
           path: packetdrill-tcpdirect
+          ssh-key: ${{ secrets.PACKETDRILL_SSH_KEY }}
           ref: ${{ env.PACKETDRILL_VERSION }}
 
       - name: Install the TCPDirect build and test dependencies


### PR DESCRIPTION
1) Bumps the checkout version from v4->v5
2) Adds the ability of packetdrill deploykey so those tests can be run