### PR TITLE
ON-16925: add attribute to control TPH

### DIFF
--- a/src/include/zf_internal/attr_tmpl.h
+++ b/src/include/zf_internal/attr_tmpl.h
@@ -357,6 +357,15 @@ ZF_ATTR(int, shrub_controller, stable, -1, NULL,
         "TCPDirect expects the shrub controller to be spawned manually separately to \n"
         "the application using the zf_stack.")
 
+ZF_ATTR(str, tph_mode, stable, "off", "off",
+        "zf_vi",
+
+        "Set the PCIe TPH mode to use for SDCI. Set to:\n"
+        " 'off' to disable use of TPH\n"
+        " 'nost' to enable use of TPH without steering tags\n"
+        " 'st' to enable use of TPH with steering tags\n"
+        "Using steering tags is recommended on platforms that support it.")
+
 /**********************************************************************
  * zf_pool attributes.
  */

--- a/src/lib/zf/private/stack_alloc.c
+++ b/src/lib/zf/private/stack_alloc.c
@@ -438,6 +438,31 @@ static int zf_stack_init_ctpio_nic_config(zf_stack_impl* sti,
 }
 
 
+static int zf_stack_init_tph_mode(struct zf_stack_impl* sti,
+                                  struct zf_attr* attr,
+                                  unsigned* vi_flags)
+{
+  zf_stack* st = &sti->st;
+
+  if( attr->tph_mode != NULL ) {
+    if( ! strcmp(attr->tph_mode, "nost") ) {
+      *vi_flags |= EF_VI_ENABLE_TPH;
+    }
+    else if( ! strcmp(attr->tph_mode, "st") ) {
+      *vi_flags |= EF_VI_ENABLE_TPH;
+      *vi_flags |= EF_VI_TPH_TAG_MODE;
+    }
+    else if( strcmp(attr->tph_mode, "off") ) {
+      zf_log_stack_err(st,
+                       "Bad tph_mode attribute; must be one of: off, nost, "
+                       "st\n");
+      return -EINVAL;
+    }
+  }
+  return 0;
+}
+
+
 static void zf_stack_init_zock_resource(zf_stack_impl* sti,
                                         struct zf_attr* attr)
 {
@@ -889,6 +914,10 @@ int zf_stack_alloc(struct zf_attr* attr, struct zf_stack** stack_out)
 
   if( attr->tx_timestamping )
     vi_flags |= EF_VI_TX_TIMESTAMPS;
+
+  rc = zf_stack_init_tph_mode(sti, attr, &vi_flags);
+  if( rc < 0 )
+    goto fail2;
 
   int ctpio_mode;
   rc = zf_stack_init_ctpio_stack_config(sti, attr, &ctpio_mode);


### PR DESCRIPTION
### Bad attribute value
```
$ LD_LIBRARY_PATH=~/git/onload_internal/build/gnu_x86_64/lib/cplane ZF_ATTR=interface=enp193s0f0\;tph_mode=qwerty ./build/gnu_x86_64/bin/zf_apps/static/zfsink 192.168.100.100:26262
  1000 | Bad tph_mode attribute; must be one of: none, enable, steering
ERROR: main: ZF_TRY(zf_stack_alloc(attr, &stack)) failed
ERROR: at src/tests/zf_apps//zfsink.c:265
ERROR: rc=-22 (Invalid argument) errno=0
Aborted (core dumped)
```

### No tph_mode attribute

```
$ LD_LIBRARY_PATH=~/git/onload_internal/build/gnu_x86_64/lib/cplane ZF_ATTR=interface=enp193s0f0 ./build/gnu_x86_64/bin/zf_apps/static/zfsink 192.168.100.100:26262
```

```
$ LD_LIBRARY_PATH=~/git/onload_internal/build/gnu_x86_64/lib/cplane  ./build/gnu_x86_64/bin/zf_stackdump dump | grep flags
nic0: vi=4 vi_flags=3000000 nic_flags=1 intf=enp193s0f0 index=6 hw=5A0
```

### tph_mode=off

```
$ LD_LIBRARY_PATH=~/git/onload_internal/build/gnu_x86_64/lib/cplane ZF_ATTR=interface=enp193s0f0\;tph_mode=off ./build/gnu_x86_64/bin/zf_apps/static/zfsink 192.168.100.100:26262
```

```
$ LD_LIBRARY_PATH=~/git/onload_internal/build/gnu_x86_64/lib/cplane  ./build/gnu_x86_64/bin/zf_stackdump dump | grep flags
nic0: vi=4 vi_flags=3000000 nic_flags=1 intf=enp193s0f0 index=6 hw=5A0
```

### tph_mode=nost

```
$ LD_LIBRARY_PATH=~/git/onload_internal/build/gnu_x86_64/lib/cplane ZF_ATTR=interface=enp193s0f0\;tph_mode=nost ./build/gnu_x86_64/bin/zf_apps/static/zfsink 192.168.100.100:26262
```

```
$ LD_LIBRARY_PATH=~/git/onload_internal/build/gnu_x86_64/lib/cplane  ./build/gnu_x86_64/bin/zf_stackdump dump | grep flags
nic0: vi=4 vi_flags=43000000 nic_flags=1 intf=enp193s0f0 index=6 hw=5A0
```



### tph_mode=st

```
$ LD_LIBRARY_PATH=~/git/onload_internal/build/gnu_x86_64/lib/cplane ZF_ATTR=interface=enp193s0f0\;tph_mode=st ./build/gnu_x86_64/bin/zf_apps/static/zfsink 192.168.100.100:26262
```

```
$ LD_LIBRARY_PATH=~/git/onload_internal/build/gnu_x86_64/lib/cplane  ./build/gnu_x86_64/bin/zf_stackdump dump | grep flags
nic0: vi=4 vi_flags=c3000000 nic_flags=1 intf=enp193s0f0 index=6 hw=5A0
```


