### PR TITLE
ON-17116: disable overlapped receive on unsupported EFCT architectures

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
 tcpdirect-9.1.1
 ---------------
 
-No changes since previous version
+ON-17116: disable overlapped receive on unsupported EFCT architectures
 
 
 tcpdirect-9.1.0.4

--- a/src/include/zf_internal/private/zf_stack_def.h
+++ b/src/include/zf_internal/private/zf_stack_def.h
@@ -120,6 +120,7 @@ struct zf_stack {
      * Typically set when unrelated user visible event interrupted pftf.
      */
     unsigned event_occurred_carry;
+    bool can_overlap;
   } pftf;
 
   bool x4_shared_mode;

--- a/src/include/zf_internal/private/zf_stack_rx.h
+++ b/src/include/zf_internal/private/zf_stack_rx.h
@@ -199,7 +199,7 @@ zf_stack_handle_rx_tcp(struct zf_stack* stack, const char* iov_base,
 
       tcp_cut_through(tcp, payload, payload_len);
 
-      if( len == 0 &&
+      if( len == 0 && stack->pftf.can_overlap &&
           tcp->w.event.events & ZF_EPOLLIN_OVERLAPPED &&
           /* make sure there has been no other pkt on rxq */
           zfr_queue_packets_unread_n(&tcp->tsr) == 1 ) {
@@ -376,7 +376,7 @@ zf_stack_handle_rx_udp(struct zf_stack* st, const char* iov_base,
                          ip->daddr, 0, udp->dest, 0, &index) == 0 )) {
     struct zf_udp_rx* udp_rx = &st->udp_rx[index];
 
-    if( len == 0 &&
+    if( len == 0 && st->pftf.can_overlap &&
         udp_rx->w.event.events & ZF_EPOLLIN_OVERLAPPED ) {
 
       zf_assert_nflags(udp_rx->w.readiness_mask, ZF_EPOLLIN_OVERLAPPED);

--- a/src/lib/zf/private/reactor.c
+++ b/src/lib/zf/private/reactor.c
@@ -643,6 +643,7 @@ __zf_reactor_perform(struct zf_stack* st, unsigned spin_cnt)
              * but it's advantageous to set these sooner rather than later. */
             st->future_nic_id = nic;
             st->future_packet_id = next_packet_id;
+            st->pftf.can_overlap = ! is_efct;
 
             /* A packet is arriving from the future.  We can begin protocol-
              * processing in the hope that the rest of the packet arrives


### PR DESCRIPTION
Overlapped receive would fail badly on unsupported architectures, where we don't have access to the packet buffers to poison them appropriately before posting. Without the poison we would report that all data was available immediately, when it might still be in transit.

Don't report ZF_EPOLLIN_OVERLAPPED in this case. We will still handle future packets internally, but the app will receive the data normally when the packet has completed.