### PR TITLE
ON-17271: add attribute to make VLAN capability optional

### DIFF
--- a/src/include/zf_internal/attr_tmpl.h
+++ b/src/include/zf_internal/attr_tmpl.h
@@ -200,6 +200,16 @@ ZF_ATTR(int, tx_error_recovery, stable, 1, "on",
         "Defines whether a stack should attempt to recover from a TX error "
         "event. (enabled by default)")
 
+ZF_ATTR(int, disable_vlan_filter_cap, stable, 0, "off",
+        "zf_stack",
+
+        "Disable VLAN filter capability on stack initialisation. "
+        "When set to 1, the VLAN filter flag is not set on the NIC even if "
+        "the hardware reports support for it, so VLAN filtering is not applied "
+        "to RX filter specs. "
+        "Values: 0 - use hardware capability (default), "
+        "1 - suppress VLAN filter capability.")
+
 
 /**********************************************************************
  * zf_vi attributes.

--- a/src/lib/zf/private/stack_alloc.c
+++ b/src/lib/zf/private/stack_alloc.c
@@ -561,7 +561,9 @@ static void zf_stack_init_state(struct zf_stack_impl* sti,
 }
 
 
-static int zf_stack_init_nic_capabilities(struct zf_stack* st, int nicno)
+static int zf_stack_init_nic_capabilities(struct zf_stack* st,
+                                          const struct zf_attr* attr,
+                                          int nicno)
 {
   struct zf_stack_impl* sti = ZF_CONTAINER(struct zf_stack_impl, st, st);
   unsigned long vlan_filters;
@@ -604,7 +606,7 @@ static int zf_stack_init_nic_capabilities(struct zf_stack* st, int nicno)
 
   rc = ef_pd_capabilities_get(dh, pd, dh, EF_VI_CAP_RX_FILTER_TYPE_IP_VLAN,
                               &vlan_filters);
-  if( rc == 0 && vlan_filters != 0 )
+  if( rc == 0 && vlan_filters != 0 && !attr->disable_vlan_filter_cap )
     sti->nic[nicno].flags |= ZF_RES_NIC_FLAG_VLAN_FILTERS;
 
   return 0;
@@ -678,7 +680,7 @@ int zf_stack_init_nic_resources(struct zf_stack_impl* sti,
     goto fail0;
   }
 
-  rc = zf_stack_init_nic_capabilities(st, nicno);
+  rc = zf_stack_init_nic_capabilities(st, attr, nicno);
   if( rc < 0 )
     goto fail1;
 


### PR DESCRIPTION
## Background

On X2 adapters, the NIC does not support qualified VLAN filters in
low-latency mode. As a result, a single TCPDirect stack bound to a VLAN
interface (e.g. `enp65s0f0.100`) will receive multicast UDP traffic
regardless of the VLAN tag carried in the packet. This allows one stack
to service traffic arriving on multiple VLANs — a behaviour some
customers depend on.

## Problem

X4 adapters do support qualified VLAN filters in low-latency mode + express dp
(`EF_VI_CAP_RX_FILTER_TYPE_IP_VLAN`). TCPDirect detects this capability
at stack initialisation and sets `ZF_RES_NIC_FLAG_VLAN_FILTERS` on the
NIC, which causes `ef_filter_spec_set_vlan()` to be applied to multicast
UDP RX filter specs. The practical consequence is that a packet arriving
on a different VLAN than the one the stack is bound to is silently
dropped — contrary to the established X2 behaviour.

Example: stack bound to `enp65s0f0.100`, packet sent on VLAN 101 —
The packet is not received:

```
$ ZF_ATTR="interface=enp65s0f0.100;disable_vlan_filter_cap=0" \
    zfsink 225.1.2.3:1234
# pkt-rate  bandwidth(Mbps)      total-pkts
         0                0                0
         0                0                0   ← packet on VLAN 101 not received
```

## Solution

A new stack attribute `disable_vlan_filter_cap` (default `0`) has been
introduced. When set to `1`, the VLAN filter flag is suppressed during
NIC capability initialisation, regardless of what the hardware reports.
This restores the X2 legacy behaviour: the VLAN tag is not included in
the RX filter spec, and a single stack can receive multicast traffic
from multiple VLANs.

### Changes

- **`src/include/zf_internal/attr_tmpl.h`** — new `stable` integer
  attribute `disable_vlan_filter_cap` (default `0`).
- **`src/lib/zf/private/stack_alloc.c`** — `zf_stack_init_nic_capabilities()`
  now accepts `const struct zf_attr*` and gates the
  `ZF_RES_NIC_FLAG_VLAN_FILTERS` assignment on
  `!attr->disable_vlan_filter_cap`.

### Usage

```
ZF_ATTR="interface=enp65s0f0.100;disable_vlan_filter_cap=1" zfsink 225.1.2.3:1234
```

## Verification

With `disable_vlan_filter_cap=1`, a multicast packet sent on VLAN 101 is
correctly received by a stack bound to `enp65s0f0.100` (VLAN 100):

```
$ ZF_ATTR="interface=enp65s0f0.100;log_level=0xFFFFFFF;disable_vlan_filter_cap=1" \
    zfsink 225.1.2.3:1234
ZF library initialized
  1000 | Interface enp65s0f0 is not in low latency mode.
  1000 | Low latency mode is recommended for best latency with TCPDirect.
  1000 | rxq_size=1023 txq_size=511 evq_size=1014 rx_prefix_len=14
  1000 | PIO not supported by efct interface but pio=3. Not attempting to allocate PIO buffer.
# pkt-rate  bandwidth(Mbps)      total-pkts
         0                0                0
enp65s0f0.100/004  1044 | UDP RX#00 | __zf_stack_handle_rx_udp: pkt 0 ... len 22
         1                0                1   ← packet on VLAN 101 received
```

## Summary of tests on X2 and X4:

<img width="442" height="130" alt="image" src="https://github.com/user-attachments/assets/ffb4ce74-a036-4b6c-936d-c66e446ee01b" />

## Notes

- The attribute has no effect on unicast or non-VLAN stacks; it is a
  no-op when the hardware does not report `EF_VI_CAP_RX_FILTER_TYPE_IP_VLAN`.
- Setting `disable_vlan_filter_cap=1` on X4 in a deployment where strict
  per-VLAN isolation is required would be a misconfiguration; the
  The attribute is intentionally opt-in.