### PR TITLE
On 17299: fix incorrect ZF warn about low-latency mode on X4/EFCT NICs

### DIFF
--- a/src/include/zf_internal/private/zf_stack_def.h
+++ b/src/include/zf_internal/private/zf_stack_def.h
@@ -183,6 +183,7 @@ struct zf_stack {
 #define ZF_RES_NIC_FLAG_VLAN_FILTERS 0x1
 #define ZF_RES_NIC_FLAG_RX_LL        0x2
 #define ZF_RES_NIC_FLAG_TX_LL        0x4
+#define ZF_RES_NIC_FLAG_SHARED_RXQ   0x8
 
 #define EXPRESS_MODE 0
 #define ENTERPRISE_MODE 1

--- a/src/lib/zf/private/stack_alloc.c
+++ b/src/lib/zf/private/stack_alloc.c
@@ -572,20 +572,28 @@ static int zf_stack_init_nic_capabilities(struct zf_stack* st, int nicno)
 
   sti->nic[nicno].flags = 0;
 
-  rc = ef_pd_capabilities_get(dh, pd, dh, EF_VI_CAP_RX_FW_VARIANT, &variant);
-  if( rc != 0 ) {
-    zf_log_stack_err(st, "Failed to query RX mode for interface %s (rc %d)\n",
-                         sti->nic[nicno].if_name, rc);
-    return rc;
+  rc = ef_pd_capabilities_get(dh, pd, dh, EF_VI_CAP_RX_SHARED, &variant);
+  if( rc == 0 && variant != 0 ) {
+    /* X4/EFCT NICs use a shared RX queue across VIs; the per-VI firmware
+     * datapath variant concept does not apply, so skip that check. */
+    sti->nic[nicno].flags |= ZF_RES_NIC_FLAG_SHARED_RXQ;
   }
-  else if( variant != MC_CMD_GET_CAPABILITIES_OUT_RXDP_LOW_LATENCY &&
-           variant != MC_CMD_GET_CAPABILITIES_OUT_RXDP ) {
-    zf_log_stack_err(st, "Interface %s is not in supported mode for RX (%d).\n",
-                     sti->nic[nicno].if_name, variant);
-    return -EOPNOTSUPP;
+  else {
+    rc = ef_pd_capabilities_get(dh, pd, dh, EF_VI_CAP_RX_FW_VARIANT, &variant);
+    if( rc != 0 ) {
+      zf_log_stack_err(st, "Failed to query RX mode for interface %s (rc %d)\n",
+                           sti->nic[nicno].if_name, rc);
+      return rc;
+    }
+    else if( variant != MC_CMD_GET_CAPABILITIES_OUT_RXDP_LOW_LATENCY &&
+             variant != MC_CMD_GET_CAPABILITIES_OUT_RXDP ) {
+      zf_log_stack_err(st, "Interface %s is not in supported mode for RX (%d).\n",
+                       sti->nic[nicno].if_name, variant);
+      return -EOPNOTSUPP;
+    }
+    if( variant == MC_CMD_GET_CAPABILITIES_OUT_RXDP_LOW_LATENCY )
+      sti->nic[nicno].flags |= ZF_RES_NIC_FLAG_RX_LL;
   }
-  if( variant == MC_CMD_GET_CAPABILITIES_OUT_RXDP_LOW_LATENCY )
-    sti->nic[nicno].flags |= ZF_RES_NIC_FLAG_RX_LL;
 
   rc = ef_pd_capabilities_get(dh, pd, dh, EF_VI_CAP_TX_FW_VARIANT, &variant);
   if( rc != 0 ) {
@@ -682,8 +690,9 @@ int zf_stack_init_nic_resources(struct zf_stack_impl* sti,
   if( rc < 0 )
     goto fail1;
 
-  if( !(sti->nic[nicno].flags & ZF_RES_NIC_FLAG_RX_LL) ||
-      !(sti->nic[nicno].flags & ZF_RES_NIC_FLAG_TX_LL) ) {
+  if( !(sti->nic[nicno].flags & ZF_RES_NIC_FLAG_SHARED_RXQ) &&
+      ( !(sti->nic[nicno].flags & ZF_RES_NIC_FLAG_RX_LL) ||
+        !(sti->nic[nicno].flags & ZF_RES_NIC_FLAG_TX_LL) ) ) {
     zf_log_stack_warn(st, "Interface %s is not in low latency mode.\n",
                           sti->nic[nicno].if_name);
     zf_log_stack_warn(st, "Low latency mode is recommended for best "


### PR DESCRIPTION
When initialising a TCPDirect stack on an X4 or X3 NIC, the following spurious warning is emitted even though the interface is operating correctly:

```
andresa@ubuntu-server:~/git/tcpdirect$ ZF_ATTR="interface=enp65s0f0.100;log_level=0xFFFFFFF" ./build/gnu_x86_64-zf-devel/bin/zf_apps/static/zfsink 225.1.2.3:1234
ZF library initialized
  1000 | Interface enp65s0f0 is not in low latency mode.
  1000 | Low latency mode is recommended for best latency with TCPDirect.
  1000 | rxq_size=1023 txq_size=511 evq_size=1014 rx_prefix_len=14
  1000 | PIO not supported by efct interface but pio=3. Not attempting to allocate PIO buffer.
# pkt-rate  bandwidth(Mbps)      total-pkts
         0                0                0
```
This warning is misleading and causes confusion to our customers when, for example, an X4 card is in low latency mode, but TCPDirect says the opposite. 

After proposed fix:
```
andresa@ubuntu-server:~/git/tcpdirect$ ZF_ATTR="interface=enp65s0f0.100;log_level=0xFFFFFFF" ./build/gnu_x86_64-zf-devel/bin/zf_apps/static/zfsink 225.1.2.3:1234
ZF library initialized
  1000 | rxq_size=1023 txq_size=511 evq_size=1014 rx_prefix_len=14
  1000 | PIO not supported by efct interface but pio=3. Not attempting to allocate PIO buffer.
# pkt-rate  bandwidth(Mbps)      total-pkts
         0                0                0
```