### PR TITLE
ON-17171: set the max number of evq events in zf_emu

### DIFF
--- a/src/lib/zf/private/zf_emu.c
+++ b/src/lib/zf/private/zf_emu.c
@@ -2264,6 +2264,7 @@ static int emu_ef_vi_alloc_from_pd(ef_vi* vi, ef_driver_handle vi_dh,
 
   vi->evq_mask = evq_mask;
   vi->evq_base = (char*) evi->evq.descriptors;
+  vi->evq_max_events = evq_capacity;
   vi->vi_rxq.mask = evi->rxq.mask;
   vi->vi_rxq.descriptors = evi->rxq.descriptors;
   vi->vi_rxq.ids = evi->rxq.ids;


### PR DESCRIPTION
This is required to match a change in onload that adds accounting of the number of EVQ slots that remain unfilled to ensure we avoid an overflow in our EVQ.

### Testing Done
Unit tests pass when compiled again the pending onload changes.