### PR TITLE
ON-16984: Move shrub sync config to ef_vi filter calls

### DIFF
--- a/src/include/zf_internal/attr_tmpl.h
+++ b/src/include/zf_internal/attr_tmpl.h
@@ -363,6 +363,12 @@ ZF_ATTR(int, shrub_controller, stable, -1, NULL,
         "TCPDirect expects the shrub controller to be spawned manually separately to \n"
         "the application using the zf_stack.")
 
+ZF_ATTR(int, shrub_controller_buffers, stable, -1, NULL,
+        "zf_vi",
+
+        "Specify the number of buffers to request from the shrub controller. \n"
+        "A value of -1 means use the default number of buffers.")
+
 ZF_ATTR(str, tph_mode, stable, "off", "off",
         "zf_vi",
 

--- a/src/include/zf_internal/private/zf_stack_def.h
+++ b/src/include/zf_internal/private/zf_stack_def.h
@@ -289,6 +289,7 @@ struct zf_stack_impl {
   int sti_rx_datapath;
   int sti_phys_address_mode;
   int sti_shrub_controller;
+  int sti_shrub_controller_buffers;
   uint64_t sti_log_level;
   bool sti_tx_error_recovery;
   

--- a/src/lib/zf/private/stack_alloc.c
+++ b/src/lib/zf/private/stack_alloc.c
@@ -966,6 +966,7 @@ int zf_stack_alloc(struct zf_attr* attr, struct zf_stack** stack_out)
   sti->sti_rx_datapath = rx_datapath;
   sti->sti_phys_address_mode = phys_address_mode;
   sti->sti_shrub_controller = shrub_controller;
+  sti->sti_shrub_controller_buffers = attr->shrub_controller_buffers;
   sti->sti_tx_error_recovery = attr->tx_error_recovery;
 
   strncpy(sti->sti_ctpio_mode, attr->ctpio_mode, 8);

--- a/src/lib/zf/private/stack_alloc.c
+++ b/src/lib/zf/private/stack_alloc.c
@@ -657,12 +657,6 @@ int zf_stack_init_nic_resources(struct zf_stack_impl* sti,
     return -EINVAL;
   }
 
-  rc = setenv("EF_SHRUB_CONTROLLER", shrub_controller_char , 1);
-  if ( rc != 0 && shrub_controller != -1 ) {
-    zf_log_stack_err(st, "Failed to set EF_SHRUB_CONTROLLER environment variable\n");
-    return -EINVAL;
-  }
-
   if ( phys_address_mode ) {
       rc = ef_vi_capabilities_get_from_pd_flags(
              sti_nic->dh, ifindex, (ef_pd_flags)(pd_flags | EF_PD_PHYS_MODE),

--- a/src/lib/zf/rx.c
+++ b/src/lib/zf/rx.c
@@ -287,6 +287,7 @@ zfrr_hw_filter_init(struct zf_stack* st, zfrr_nic_mask nics, int proto,
 
   int nic;
   enum ef_filter_flags flags = (enum ef_filter_flags) (st->x4_shared_mode ? EF_FILTER_FLAG_SHARED_RXQ : 0 );
+  struct zf_stack_impl* sti = ZF_CONTAINER(struct zf_stack_impl, st, st);
 
   for( nic = 0; nic < st->nics_n; ++nic ) {
     if( (1ull << nic) & nics ) {

--- a/src/lib/zf/rx.c
+++ b/src/lib/zf/rx.c
@@ -295,11 +295,15 @@ zfrr_hw_filter_init(struct zf_stack* st, zfrr_nic_mask nics, int proto,
       ef_filter_spec_init(&spec, flags);
       zfrr_hw_filter_init_vlan(st, nic, proto, laddr, &spec);
 
-      if( st->x4_shared_mode && sti->sti_shrub_controller >= 0 )
+      if( st->x4_shared_mode && sti->sti_shrub_controller >= 0 ) {
         /* In shared mode, we need to set the shrub controller on the filter so
          * that it gets steered to the right place. */
         rc = ef_filter_spec_set_shrub(&spec, sti->sti_shrub_controller, -1);
-      else if( raddr != NULL )
+        if ( rc < 0 )
+          goto fail;
+      }
+
+      if( raddr != NULL )
         rc = ef_filter_spec_set_ip4_full(&spec, proto, laddr->sin_addr.s_addr,
                                          laddr->sin_port,
                                          raddr->sin_addr.s_addr,

--- a/src/lib/zf/rx.c
+++ b/src/lib/zf/rx.c
@@ -298,7 +298,7 @@ zfrr_hw_filter_init(struct zf_stack* st, zfrr_nic_mask nics, int proto,
       if( st->x4_shared_mode && sti->sti_shrub_controller >= 0 )
         /* In shared mode, we need to set the shrub controller on the filter so
          * that it gets steered to the right place. */
-        rc = ef_filter_spec_set_shrub(&spec, sti->sti_shrub_controller, -1, sti->sti_ifindex, flags);
+        rc = ef_filter_spec_set_shrub_hwport(&spec, sti->sti_shrub_controller, -1, sti->nic[nic].ifindex, flags);
       else if( raddr != NULL )
         rc = ef_filter_spec_set_ip4_full(&spec, proto, laddr->sin_addr.s_addr,
                                          laddr->sin_port,

--- a/src/lib/zf/rx.c
+++ b/src/lib/zf/rx.c
@@ -287,7 +287,6 @@ zfrr_hw_filter_init(struct zf_stack* st, zfrr_nic_mask nics, int proto,
 
   int nic;
   enum ef_filter_flags flags = (enum ef_filter_flags) (st->x4_shared_mode ? EF_FILTER_FLAG_SHARED_RXQ : 0 );
-  struct zf_stack_impl* sti = ZF_CONTAINER(struct zf_stack_impl, st, st);
 
   for( nic = 0; nic < st->nics_n; ++nic ) {
     if( (1ull << nic) & nics ) {
@@ -298,7 +297,7 @@ zfrr_hw_filter_init(struct zf_stack* st, zfrr_nic_mask nics, int proto,
       if( st->x4_shared_mode && sti->sti_shrub_controller >= 0 )
         /* In shared mode, we need to set the shrub controller on the filter so
          * that it gets steered to the right place. */
-        rc = ef_filter_spec_set_shrub_hwport(&spec, sti->sti_shrub_controller, -1, sti->nic[nic].ifindex, flags);
+        rc = ef_filter_spec_set_shrub(&spec, sti->sti_shrub_controller, -1);
       else if( raddr != NULL )
         rc = ef_filter_spec_set_ip4_full(&spec, proto, laddr->sin_addr.s_addr,
                                          laddr->sin_port,

--- a/src/lib/zf/rx.c
+++ b/src/lib/zf/rx.c
@@ -298,7 +298,8 @@ zfrr_hw_filter_init(struct zf_stack* st, zfrr_nic_mask nics, int proto,
       if( st->x4_shared_mode && sti->sti_shrub_controller >= 0 ) {
         /* In shared mode, we need to set the shrub controller on the filter so
          * that it gets steered to the right place. */
-        rc = ef_filter_spec_set_shrub(&spec, sti->sti_shrub_controller, -1);
+        rc = ef_filter_spec_set_shrub(&spec, sti->sti_shrub_controller,
+                                       sti->sti_shrub_controller_buffers);
         if ( rc < 0 )
           goto fail;
       }

--- a/src/lib/zf/rx.c
+++ b/src/lib/zf/rx.c
@@ -283,18 +283,23 @@ zfrr_hw_filter_init(struct zf_stack* st, zfrr_nic_mask nics, int proto,
                     ef_filter_cookie cookies[ZF_MAX_NICS])
 {
   int rc;
-
   zf_assume(nics);
 
   int nic;
   enum ef_filter_flags flags = (enum ef_filter_flags) (st->x4_shared_mode ? EF_FILTER_FLAG_SHARED_RXQ : 0 );
+  struct zf_stack_impl* sti = ZF_CONTAINER(struct zf_stack_impl, st, st);
+
   for( nic = 0; nic < st->nics_n; ++nic ) {
     if( (1ull << nic) & nics ) {
       ef_filter_spec spec;
       ef_filter_spec_init(&spec, flags);
       zfrr_hw_filter_init_vlan(st, nic, proto, laddr, &spec);
 
-      if( raddr != NULL )
+      if( st->x4_shared_mode && sti->sti_shrub_controller >= 0 )
+        /* In shared mode, we need to set the shrub controller on the filter so
+         * that it gets steered to the right place. */
+        rc = ef_filter_spec_set_shrub(&spec, sti->sti_shrub_controller, -1, sti->sti_ifindex, flags);
+      else if( raddr != NULL )
         rc = ef_filter_spec_set_ip4_full(&spec, proto, laddr->sin_addr.s_addr,
                                          laddr->sin_port,
                                          raddr->sin_addr.s_addr,

--- a/src/lib/zf/zf_stackdump.c
+++ b/src/lib/zf/zf_stackdump.c
@@ -49,6 +49,7 @@ void dump_attributes(SkewPointer<zf_stack_impl> stimpl)
     : "express"));
   zf_dump("phys_address_mode=%d\n", stimpl->sti_phys_address_mode);
   zf_dump("shrub_controller=%d\n", stimpl->sti_shrub_controller);
+  zf_dump("shrub_controller_buffers=%d\n", stimpl->sti_shrub_controller_buffers);
   zf_dump("pio=%d\n", stimpl->sti_pio);
   zf_dump("reactor_spin_count=%d\n", stimpl->sti_reactor_spin_count);
   zf_dump("tcp_timewait_ms=%d\n", stimpl->sti_tcp_timewait_ms);  


### PR DESCRIPTION
Corresponding change in tcpdirect too to enable the shrub controller in tcpdirect.