### PR TITLE
ON-17366: fix race in parallel ciul builds during zf_mkdist

### DIFF
--- a/Makefile.onload
+++ b/Makefile.onload
@@ -46,7 +46,7 @@ build_dir: $(ONLOAD_UL_BUILD_DIR)
 $(COMPAT_HDR) $(CITOOLS_LIB) $(CIUL_LIB): build_dir
 	$(MAKE) -C $(dir $@) $(ONLOAD_CFLAGS)
 
-$(CIUL_LIB): $(COMPAT_HDR)
+$(CIUL_LIB): $(COMPAT_HDR) $(ONLOAD_VERSION_HDR)
 
 clean_onload:
 	$(MAKE) clean -C $(ONLOAD_UL_BUILD_DIR)


### PR DESCRIPTION
## Summary

- Add `$(ONLOAD_VERSION_HDR)` as a prerequisite of `$(CIUL_LIB)` in `Makefile.onload` to prevent two concurrent sub-makes in the ciul directory during parallel `zf_mkdist` builds
- The race was introduced by ON-12878, which removed `CPLANE_LIB` and its dependency line that had transitively serialized these builds
- This is a genuine dependency (`vi_init.o` requires the generated `onload_version.h`), not just a serialization hack

## Test plan

- [x] `zf_mkdist` build completes successfully: http://xcb-rb-logs.xilinx.com/users/sianj/results/2026/04/29/0_dibench_16-26-11