### PR TITLE
ON-15958: Adding keepalive to TCP Direct

### DIFF
--- a/src/include/zf_internal/attr_tmpl.h
+++ b/src/include/zf_internal/attr_tmpl.h
@@ -148,6 +148,29 @@ ZF_ATTR(int, tcp_finwait_ms, stable, ZF_TCP_TIMEWAIT_TIME_MS,
 
         "Length of TCP FIN-WAIT-2 timer in ms, 0 - disabled.")
 
+ZF_ATTR(int, tcp_keepalive, stable, 1, NULL,
+        "zf_stack",
+        
+        "Enable TCP keepalive (\"on\" by default).")
+
+ZF_ATTR(int, tcp_keepalive_intvl_ms, stable, ZF_TCP_KEEPALIVE_INTVL_MS,
+        "net.ipv4.tcp_keepalive_intvl",
+        "zf_stack",
+
+        "Length of TCP KEEPALIVE interval timer between two probes in ms, 0 - disabled")
+
+ZF_ATTR(int, tcp_keepalive_probes, stable, ZF_TCP_KEEPALIVE_PROBES,
+        "net.ipv4.tcp_keepalive_probes",
+        "zf_stack",
+
+        "Number of KEEPALIVE probes before resetting the connection")
+
+ZF_ATTR(int, tcp_keepalive_time_ms, stable, ZF_TCP_KEEPALIVE_TIME_MS,
+        "net.ipv4.tcp_keepalive_time",
+        "zf_stack",
+
+        "First probe timer in ms, 0 - disabled.")
+
 /* tcp_syn_retries, tcp_synack_retries and tcp_retries default values are one
  * lower than the Linux equivalents because Linux counts transmissions and
  * TCPDirect counts retransmissions. */

--- a/src/include/zf_internal/private/zf_stack_def.h
+++ b/src/include/zf_internal/private/zf_stack_def.h
@@ -276,6 +276,10 @@ struct zf_stack_impl {
   int sti_tcp_alt_ack_rewind;
   int sti_tcp_delayed_ack;
   int sti_tcp_finwait_ms;
+  // TODO: keepalive
+  int sti_tcp_keepalive;
+  int sti_tcp_keepalive_time_ms;
+  int sti_tcp_keepalive_intvl_ms;
   int sti_tcp_timewait_ms;
   int sti_tcp_wait_for_time_wait; 
   int sti_tx_ring_max;

--- a/src/include/zf_internal/tcp.h
+++ b/src/include/zf_internal/tcp.h
@@ -281,9 +281,17 @@ tcp_rx_common_tail(zf_stack* st, zf_tcp* tcp)
   if( tcp->pcb.flags & TF_ACK_DELAY )
     zf_tcp_timers_timer_start(tcp, ZF_TCP_TIMER_DACK,
                               zf_tcp_timers_dack_timeout(tcp));
+  // TODO: keepalive. 
+  // TODO: implement the timer swap between the initial time and interval.
+  // TODO: it should be done within the keepalive_timeout function
+
+  // TODO: Check if this is in the right place, as there might be a corner case 
+  // TODO: where we're processing packets and KA must be deactivated.
+
+  zf_tcp_timers_timer_start(tcp, ZF_TCP_TIMER_KEEPALIVE, 
+                            zf_tcp_timers_keepalive_time_timeout(st));
   return event_occurred;
 }
-
 
 extern bool tcp_is_orphan(zf_tcp* tcp);
 

--- a/src/include/zf_internal/tcp_opt.h
+++ b/src/include/zf_internal/tcp_opt.h
@@ -69,6 +69,14 @@
  */
 #define ZF_TCP_TIMEWAIT_TIME_MS 120000
 
+/**
+ * Default keepalive time in ms  
+ */
+// TODO: keepalive
+// default values mimicking the kernel
+#define ZF_TCP_KEEPALIVE_TIME_MS 7200000
+#define ZF_TCP_KEEPALIVE_INTVL_MS 7500
+#define ZF_TCP_KEEPALIVE_PROBES 9
 
 #endif /* __ZF_INT_TCP_OPT_H__ */
 

--- a/src/include/zf_internal/tcp_tx.h
+++ b/src/include/zf_internal/tcp_tx.h
@@ -302,3 +302,17 @@ static inline void tcp_tx_cancel_delayed_ack(struct zf_tcp* tcp)
   zf_tcp_timers_timer_stop(tcp, ZF_TCP_TIMER_DACK);
 }
 
+// TODO: keepalive
+static inline void tcp_tx_cancel_keep_alive(struct zf_tcp* tcp)
+{
+  struct tcp_pcb* pcb = &tcp->pcb;
+  /* 
+     update pcb to indicate the timer has been cancelled. 
+     conditions to keep counting are no longer met.
+     Actions within zf_tcp_timers_timer_stop(tcp, ZF_TCP_TIME_KEEPALIVE):
+     - reset the counter for keepalive probes
+     - back to initial long base timer for first probes   
+  */
+ pcb->sent_probes=0;
+ zf_tcp_timers_timer_stop(tcp, ZF_TCP_TIMER_KEEPALIVE);
+}

--- a/src/include/zf_internal/tcp_types.h
+++ b/src/include/zf_internal/tcp_types.h
@@ -97,6 +97,7 @@ enum zf_tcp_timer_type {
   ZF_TCP_TIMER_ZWIN,
   ZF_TCP_TIMER_TIMEWAIT,
   ZF_TCP_TIMER_FINWAIT = ZF_TCP_TIMER_TIMEWAIT,
+  ZF_TCP_TIMER_KEEPALIVE,
   ZF_TCP_TIMER_COUNT,
 };
 #define ZF_TCP_ALL_TIMERS ( (1u<<ZF_TCP_TIMER_COUNT) - 1)
@@ -194,6 +195,8 @@ struct tcp_pcb {
 #define TF_INFR        ((uint16_t)0x04U)   /* In fast recovery. */
 #define TF_ACK_NEXT    ((uint16_t)0x08U)   /* ACK next segment immediately. */
 /* 0x40u and 0x80u are available for reuse. */
+// TODO: keepalive
+#define TF_ACK_KEEPALIVE ((uint16_t)0x40U) /* Keepalive ACK. */
 #define TF_ON          ((uint16_t)0x100U) /* hack: flag is always on */
 #define TF_FASTSEND_DBG ((uint16_t)0x200U) /* tracks fast send precomputation */
 
@@ -227,6 +230,9 @@ struct tcp_pcb {
 
   uint8_t nrtx;    /* current number of retransmissions */
   uint8_t persist_backoff; /* number of subsequent zwin probe retries */
+
+  /* Keepalive probe counter */
+  uint8_t sent_probes;
 
   /* fast retransmit/recovery */
   uint8_t dupacks;

--- a/src/include/zf_internal/zf_stack.h
+++ b/src/include/zf_internal/zf_stack.h
@@ -43,6 +43,9 @@ static const zf_stack_flag ZF_STACK_FLAG_TCP_WAIT_FOR_TIME_WAIT = 0x2;
 static const zf_stack_flag ZF_STACK_FLAG_TCP_FIN_WAIT_TIMEOUT_DISABLED = 0x4;
 static const zf_stack_flag ZF_STACK_FLAG_TRANSMIT_WARM_ENABLED = 0x8;
 
+// TODO: keepalive
+static const zf_stack_flag ZF_STACK_FLAG_TCP_NO_KEEPALIVE = 0x10;
+
 #ifdef ZF_DEVEL
 /* disable sending for debug purposes */
 static const zf_stack_flag ZF_STACK_FLAG_DEVEL_NO_TX = 0x80;

--- a/src/include/zf_internal/zf_stack_common.h
+++ b/src/include/zf_internal/zf_stack_common.h
@@ -12,6 +12,9 @@ typedef uint8_t zf_stack_flag;
 struct zf_stack_config {
   int tcp_timewait_ticks;
   int tcp_finwait_ticks;
+  int tcp_keepalive_time_ticks;
+  int tcp_keepalive_intvl_ticks;
+  int tcp_keepalive_probes;
   int ctpio_threshold;
 };
 

--- a/src/include/zf_internal/zf_tcp_timers.h
+++ b/src/include/zf_internal/zf_tcp_timers.h
@@ -206,4 +206,16 @@ zf_tcp_timers_finwait_timeout(struct zf_stack* stack)
   return stack->config.tcp_finwait_ticks;
 }
 
+static inline zf_tick
+zf_tcp_timers_keepalive_time_timeout(struct zf_stack* stack)
+{
+  return stack->config.tcp_keepalive_time_ticks;
+}
+
+static inline zf_tick
+zf_tcp_timers_keepalive_intvl_timeout(struct zf_stack* stack)
+{
+  return stack->config.tcp_keepalive_intvl_ticks;
+}
+
 #endif /* __ZF_INT_TCP_TIMERS_H__ */

--- a/src/lib/zf/attr.c
+++ b/src/lib/zf/attr.c
@@ -511,6 +511,8 @@ static int zf_attr_set_from_sysctl(struct zf_attr* attr)
     attr->tcp_finwait_ms  = 1000 * opt[0];
   }
 
+  //TODO: placeholder for setting keepalive from kernel values
+
   if( zf_sysctl_get_values("net/ipv4/tcp_syn_retries", opt, 1, 0) == 0 )
     attr->tcp_syn_retries = opt[0];
 

--- a/src/lib/zf/private/stack_alloc.c
+++ b/src/lib/zf/private/stack_alloc.c
@@ -532,10 +532,18 @@ static void zf_stack_init_state(struct zf_stack_impl* sti,
     st->flags |= ZF_STACK_FLAG_TCP_NO_DELACK;
   if( attr->tcp_wait_for_time_wait )
     st->flags |= ZF_STACK_FLAG_TCP_WAIT_FOR_TIME_WAIT;
+  // TODO: keepalive
+  if ( ! attr->tcp_keepalive )
+    st->flags |= ZF_STACK_FLAG_TCP_NO_KEEPALIVE;
 
   st->config.tcp_timewait_ticks = attr->tcp_timewait_ms / TCP_TMR_INTERVAL;
   st->config.tcp_finwait_ticks = attr->tcp_finwait_ms / TCP_TMR_INTERVAL;
+  //TODO: keepalive above-values should be included in the zf_stackdump as well
+  st->config.tcp_keepalive_time_ticks = attr->tcp_keepalive_time_ms / TCP_TMR_INTERVAL;
+  st->config.tcp_keepalive_intvl_ticks = attr->tcp_keepalive_intvl_ms / TCP_TMR_INTERVAL;
+  st->config.tcp_keepalive_probes = attr->tcp_keepalive_probes;
 
+  // TODO: there should be a way to disable keepalive
   if( attr->tcp_finwait_ms == 0 )
     st->flags |= ZF_STACK_FLAG_TCP_FIN_WAIT_TIMEOUT_DISABLED;
 
@@ -959,6 +967,10 @@ int zf_stack_alloc(struct zf_attr* attr, struct zf_stack** stack_out)
   sti->sti_tcp_alt_ack_rewind = attr->tcp_alt_ack_rewind;
   sti->sti_tcp_delayed_ack = attr->tcp_delayed_ack;
   sti->sti_tcp_finwait_ms = attr->tcp_finwait_ms;
+  // TODO: keepalive
+  sti->sti_tcp_keepalive = attr->tcp_keepalive;
+  sti->sti_tcp_keepalive_time_ms = attr->tcp_keepalive_time_ms;
+  sti->sti_tcp_keepalive_intvl_ms = attr->tcp_keepalive_intvl_ms;
   sti->sti_tcp_timewait_ms = attr->tcp_timewait_ms;
   sti->sti_tcp_wait_for_time_wait = attr->tcp_wait_for_time_wait; 
   sti->sti_tx_timestamping = attr->tx_timestamping;

--- a/src/lib/zf/tcp_core.c
+++ b/src/lib/zf/tcp_core.c
@@ -169,6 +169,8 @@ void tcp_do_transition(struct zf_tcp* tcp, enum tcp_state new_state)
 
     zf_muxer_mark_waitable_ready(&tcp->w, EPOLLIN | EPOLLOUT | EPOLLHUP);
     zf_tcp_timers_timer_stop(tcp, ZF_TCP_TIMER_ZWIN);
+    // Stop keepalive as it's we enter in TIME_WAIT when Initial timer is running
+    zf_tcp_timers_timer_stop(tcp, ZF_TCP_KEEPALIVE_TIME_MS);
     zf_tcp_timers_timer_start(tcp, ZF_TCP_TIMER_TIMEWAIT,
                               zf_tcp_timers_timewait_timeout(stack));
     break;
@@ -802,11 +804,12 @@ tcp_dump(struct zf_tcp* tcp)
           pcb->rttest, pcb->rtseq, pcb->sa, pcb->sv);
   zf_dump("  cong: nrtx=%u dupacks=%u persist_backoff=%u\n",
           pcb->nrtx, pcb->dupacks, pcb->persist_backoff);
-  zf_dump("  timers: %s%s%s%s\n",
+  zf_dump("  timers: %s%s%s%s%s\n",
           pcb->timers.running & (1<<ZF_TCP_TIMER_RTO) ? "RTO " : "",
           pcb->timers.running & (1<<ZF_TCP_TIMER_DACK) ? "DACK " : "",
           pcb->timers.running & (1<<ZF_TCP_TIMER_ZWIN) ? "ZWIN " : "",
-          pcb->timers.running & (1<<ZF_TCP_TIMER_TIMEWAIT) ? "TIMEWAIT " : "");
+          pcb->timers.running & (1<<ZF_TCP_TIMER_TIMEWAIT) ? "TIMEWAIT " : "",
+          pcb->timers.running & (1<<ZF_TCP_TIMER_KEEPALIVE) ? "KEEPALIVE " : "");
   zf_dump("  ooo: added=%u removed=%u replaced=%u\n", pcb->ooo_added,
           pcb->ooo_removed, pcb->ooo_replaced);
   zf_dump("  ooo: handling_deferred=%u dropped_nomem=%u drop_overfilled=%u\n",

--- a/src/lib/zf/tcp_in.c
+++ b/src/lib/zf/tcp_in.c
@@ -734,11 +734,30 @@ void tcp_configure_rto_zwin_timers(struct zf_tcp* tcp)
       pcb->persist_backoff = 0;
       zf_tcp_timers_timer_start(tcp, ZF_TCP_TIMER_ZWIN,
                                 tcp_timers_zwin_timeout(tcp));
+    } else if( ! zf_tcp_timers_timer_is_active(tcp, ZF_TCP_TIMER_ZWIN)) {
+      struct zf_stack* stack = zf_stack_from_zocket(tcp);
+      tcp->pcb.flags |= (TF_ACK_KEEPALIVE);
+      tcp->pcb.sent_probes=0;
+      // TODO: keepalive: check that the timer is not restarting forever and SYN sent not getting a
+      // TODO:            reply is correctly handled by SYN retry algorithm.
+      zf_tcp_timers_timer_start(tcp, ZF_TCP_TIMER_KEEPALIVE,
+                                zf_tcp_timers_keepalive_time_timeout(stack));
     }
   }
-  else
+  else {
+   // TODO:   RTO should only be started when data segments being queued. 
+   //         But I wonder if control packets or ACKs that are queued will get 
+   //         into this part of the code; which makes the transition between 
+   //         states more tricky. Aparently it is not the case (simple removal and
+   //         test does not get into this case).
+   //           
+   if( zf_tcp_timers_timer_is_active(tcp, ZF_TCP_TIMER_KEEPALIVE) ) {
+      zf_tcp_timers_timer_stop(tcp, ZF_TCP_TIMER_KEEPALIVE);
+      tcp->pcb.sent_probes=0;
+   }
     zf_tcp_timers_timer_start(tcp, ZF_TCP_TIMER_RTO,
                               zf_tcp_timers_rto_timeout(tcp));
+  }
 }
 
 /* Returns the configured initial congestion window, or 10 * MSS by default. */
@@ -842,6 +861,11 @@ bool tcp_process(struct zf_tcp* tcp, struct tcp_seg* seg, uint8_t* recv_flags)
     return false;
   }
   
+  // TODO: keepalive cancel timer (it might imply different things depending on the TCP state!)
+  // TODO: it is still missing a study of the different implications
+  if ( pcb->flags & TF_ACK_KEEPALIVE )
+      tcp_tx_cancel_keep_alive(tcp);
+
   /* Do different things depending on the TCP state. */
   switch (pcb->state) {
   case SYN_SENT:
@@ -1127,6 +1151,11 @@ tcp_frequent_sync_path(zf_stack* st, zf_tcp* tcp, struct tcphdr* tcp_hdr,
 
   tcp_dack_flags_flick(pcb);
 
+  // TODO: keepalive 
+  // cancel keepalive timer (along with delayed ack flag flick)
+  if ( pcb->flags & TF_ACK_KEEPALIVE )
+      tcp_tx_cancel_keep_alive(tcp);
+  
   /* Announced window must be updated after payload has been queued,
    * including if this happened earlier in the cut-through case. */
   tcp_update_rcv_ann_wnd(pcb);

--- a/src/lib/zf/tcp_out.c
+++ b/src/lib/zf/tcp_out.c
@@ -842,6 +842,9 @@ int tcp_send_empty_ack(struct zf_tcp* tcp, bool zero_win_probe)
   zf_log_tcp_tx_trace(tcp, "%s: sending ACK for %u rcv ann win %u\n",
                       __func__, tcp->pcb.rcv_nxt, pcb->rcv_ann_wnd);
 
+  printf("%s: sending ACK for %u rcv ann win %u\n",
+                      __func__, tcp->pcb.rcv_nxt, pcb->rcv_ann_wnd);
+
   zf_tx_iphdr(&tcp->tst)->tot_len = htons(TCP_HLEN + IP_HLEN);
 
   tcp_send_with_tcp_header(tcp, 0, 0,
@@ -1316,6 +1319,34 @@ tcp_tmr(struct zf_tcp* tcp, int timers_expired)
     zf_log_timer_trace(tcp, "%s: finwait\n", __func__);
     tcp_finwait_timeout(stack, tcp);
     return event_occurred;
+  }
+
+  // TODO: check when this does not expire because it is constantly reset upon ACK / DATA arrival. 
+  // TODO: check how this timer interacts with RTO.
+  if( timers_expired & (1u << ZF_TCP_TIMER_KEEPALIVE)) {
+    // TODO: for now, just report the timer expiring:
+    zf_log_timer_trace(tcp, "%s: keepalive\n", __func__);
+    // IMO keepalive should not interfere with possible RTO firing as 
+    // RTO implies retransmissions.
+
+    printf("sent probes: %i.\n", pcb->sent_probes);
+
+    if ( pcb->sent_probes >= stack->config.tcp_keepalive_probes ) {
+       zf_log_timer_trace(tcp, "%s: Resetting connection due Lack of response upon keep alive check.\n", __func__);
+       printf("Resetting connection due Lack of response upon keep alive check.\n");
+
+       return event_occurred; 
+    }
+
+    pcb->sent_probes++;
+    
+    if( pcb->flags & TF_ACK_KEEPALIVE ) {
+      tcp_send_empty_ack(tcp, true); // True is for zwin probing, but may do the trick.
+      zf_tcp_timers_timer_start(tcp, ZF_TCP_TIMER_KEEPALIVE, 
+                                zf_tcp_timers_keepalive_intvl_timeout(stack));
+      printf("Sending probe #%i.\n", pcb->sent_probes);
+    }
+
   }
 
   if( ~timers_expired & (1u << ZF_TCP_TIMER_RTO))

--- a/src/lib/zf/zf_stackdump.c
+++ b/src/lib/zf/zf_stackdump.c
@@ -51,13 +51,15 @@ void dump_attributes(SkewPointer<zf_stack_impl> stimpl)
   zf_dump("shrub_controller=%d\n", stimpl->sti_shrub_controller);
   zf_dump("pio=%d\n", stimpl->sti_pio);
   zf_dump("reactor_spin_count=%d\n", stimpl->sti_reactor_spin_count);
-  zf_dump("tcp_timewait_ms=%d\n", stimpl->sti_tcp_timewait_ms);  
-  zf_dump("alt_buf_size=%d\n", stimpl->sti_alt_buf_size);  
-  zf_dump("alt_count=%d\n", stimpl->sti_alt_count);  
+  zf_dump("tcp_timewait_ms=%d\n", stimpl->sti_tcp_timewait_ms);
+  zf_dump("alt_buf_size=%d\n", stimpl->sti_alt_buf_size);
+  zf_dump("alt_count=%d\n", stimpl->sti_alt_count);
   zf_dump("rx_ring_refill_batch_size=%d\n", stimpl->sti_rx_ring_refill_batch_size);
-  zf_dump("tcp_alt_ack_rewind=%d\n", stimpl->sti_tcp_alt_ack_rewind);  
-  zf_dump("tcp_delayed_ack=%d\n", stimpl->sti_tcp_delayed_ack);  
-  zf_dump("tcp_finwait_ms=%d\n", stimpl->sti_tcp_finwait_ms);  
+  zf_dump("tcp_alt_ack_rewind=%d\n", stimpl->sti_tcp_alt_ack_rewind);
+  // TODO: keepalive
+  zf_dump("tcp_keepalive=%d\n", stimpl->sti_tcp_keepalive);
+  zf_dump("tcp_delayed_ack=%d\n", stimpl->sti_tcp_delayed_ack);
+  zf_dump("tcp_finwait_ms=%d\n", stimpl->sti_tcp_finwait_ms);
   zf_dump("tcp_wait_for_time_wait=%d\n", stimpl->sti_tcp_wait_for_time_wait);  
   zf_dump("ctpio_max_frame_len=%d\n", stimpl->sti_ctpio_max_frame_len);
   zf_dump("force_separate_tx_vi=%d\n", stimpl->sti_force_separate_tx_vi);


### PR DESCRIPTION
This commit adds TCP keepalive support to TCPDirect. It introduces four new stack attributes — tcp_keepalive (enabled by default), tcp_keepalive_time_ms (delay before the first probe), tcp_keepalive_intvl_ms (interval between subsequent probes), and tcp_keepalive_probes (max probes before resetting the connection) — mirroring the standard Linux net.ipv4.tcp_keepalive_* sysctl knobs.

The implementation adds a new ZF_TCP_TIMER_KEEPALIVE timer, started when the send queue drains and no zero-window probe is active, and cancelled upon receiving any incoming data or ACK. On each timer expiry, a keepalive probe is sent (reusing the zero-window probe path), and the interval timer is restarted; once the probe count reaches the configured limit, the connection is scheduled for reset.

The change touches headers, the timer infrastructure, the TCP input path, the output path, the stack allocator, and the stackdump, and is explicitly marked as work-in-progress with several TODO comments noting open questions around interaction with the RTO timer, SYN retry handling, and state-transition edge cases.

Basic testing:

**Single probe:**

Sender:

```
ZF_ATTR="interface=enp129s0f0;tcp_keepalive_probes=1;tcp_keepalive_time_ms=4000;tcp_keepalive_intvl_ms=1000" ./build/gnu_x86_64-zf-devel/bin/zf_apps/static/zftcppingpong ping 192.168.5.2:1239
```

<img width="975" height="278" alt="image" src="https://github.com/user-attachments/assets/66f6a15e-574d-41d8-bd71-3e3bbaf9c789" />

Receiver:

```
ZF_ATTR="interface=enp129s0f0;tcp_keepalive_probes=10;tcp_keepalive_time_ms=400000;tcp_keepalive_intvl_ms=1000" ./build/gnu_x86_64-zf-devel/bin/zf_apps/static/zftcppingpong pong 192.168.5.2:1239 & ((for i in `seq 1 5`; do sleep 1; echo "in.. "$i; done) && pkill -STOP zftcppingpong)
```

<img width="975" height="275" alt="image" src="https://github.com/user-attachments/assets/59e6aca8-be4c-4abe-bc5f-2eb1405faf2c" />

App log:

```
andresa@sup-cap2:~/git/tcpdirect$ ZF_ATTR="interface=enp129s0f0;tcp_keepalive_probes=1;tcp_keepalive_time_ms=4000;tcp_keepalive_intvl_ms=1000" ./build/gnu_x86_64-zf-devel/bin/zf_apps/static/zftcppingpong ping 192.168.5.2:1239
Connecting to ponger
tcp_send_empty_ack: sending ACK for 1541617670 rcv ann win 65535
Connection established
sent probes: 0.
tcp_send_empty_ack: sending ACK for 1547842034 rcv ann win 65535
Sending probe #1.
sent probes: 1.
Resetting connection due Lack of response upon keep alive check.
sent probes: 1.
Resetting connection due Lack of response upon keep alive check.
sent probes: 1.
Resetting connection due Lack of response upon keep alive check.
sent probes: 1.
Resetting connection due Lack of response upon keep alive check.
tcp_send_empty_ack: sending ACK for 1547842046 rcv ann win 65535
mean round-trip time: 30.772 usec
Reporting half round-trip stats in nsec for 1000000 iterations
```

1. As the pause in transmission was 28s (2 secs to complete the rest about ~1 us RTT) then 30usec follows from the mean on 1 MM RTTs.

2. As observed in frame 518703 in -rcv and 518704 in -snd the TCP retransmission timeout triggers going back 33 segments. This seems to be erroneous action given that (1) at the -snd (ka sender) the TCP Keep-Alive keeps the correct sequence 6224376 whereas the RTO sends from seq=6223981 which has already been acknowledged, and (2) at the -rcv the RTO sends going back 33 segments from the same seq number 6223981 even when it has already been acknowledged. This is fixed in `ON-16552: Improving RTO performance for TCP Direct`.

<img width="636" height="112" alt="image" src="https://github.com/user-attachments/assets/5f098a8b-ea1d-4cf0-8027-622d189ba11e" />

**Two probes:**

Sender: 

<img width="975" height="227" alt="image" src="https://github.com/user-attachments/assets/30357527-6d36-463b-94e3-3b4889d16a05" />

Receiver:

<img width="975" height="241" alt="image" src="https://github.com/user-attachments/assets/6e873945-3953-482a-a831-58345b66e3ff" />

App log:

```
andresa@sup-cap2:~/git/tcpdirect$ ZF_ATTR="interface=enp129s0f0;tcp_keepalive_probes=2;tcp_keepalive_time_ms=4000;tcp_keepalive_intvl_ms=1000" ./build/gnu_x86_64-zf-devel/bin/zf_apps/static/zftcppingpong -i 500000 ping 192.168.5.2:1239
Connecting to ponger
tcp_send_empty_ack: sending ACK for 1208401315 rcv ann win 65535
Connection established
sent probes: 0.
tcp_send_empty_ack: sending ACK for 1210724767 rcv ann win 65535
Sending probe #1.
sent probes: 1.
tcp_send_empty_ack: sending ACK for 1210724767 rcv ann win 65535
Sending probe #2.
sent probes: 2.
Resetting connection due Lack of response upon keep alive check.
sent probes: 2.
Resetting connection due Lack of response upon keep alive check.
sent probes: 2.
Resetting connection due Lack of response upon keep alive check.
sent probes: 2.
Resetting connection due Lack of response upon keep alive check.
tcp_send_empty_ack: sending ACK for 1210724779 rcv ann win 65535
mean round-trip time: 83.796 usec
Reporting half round-trip stats in nsec for 500000 iterations
#       size    mean    min     median  max     %ile    stddev  iter
        12      41898   20400799056     992     10330   1962    4552664 500000
```

1. Iterations reduced to 500000 – mean rtt subject to the same computation: 40 s gap gives ~40 us rtt. 
2. RTO problem still present but fixed in ON-16552

<img width="631" height="161" alt="image" src="https://github.com/user-attachments/assets/08d24159-d9d1-4f90-aca3-feee3acc8ca2" />

Three probes:

Sender:

<img width="975" height="239" alt="image" src="https://github.com/user-attachments/assets/b2b899eb-7206-4582-ab36-5a0256182953" />

Receiver:

<img width="975" height="217" alt="image" src="https://github.com/user-attachments/assets/ab7ee870-3fb7-4024-9de1-48a774b8f471" />

App log:

```
andresa@sup-cap2:~/git/tcpdirect$ ZF_ATTR="interface=enp129s0f0;tcp_keepalive_probes=3;tcp_keepalive_time_ms=4000;tcp_keepalive_int
vl_ms=1000" ./build/gnu_x86_64-zf-devel/bin/zf_apps/static/zftcppingpong -i 500000 ping 192.168.5.2:1239
Connecting to ponger
tcp_send_empty_ack: sending ACK for 2033701109 rcv ann win 65535
Connection established
sent probes: 0.
tcp_send_empty_ack: sending ACK for 2035920185 rcv ann win 65535
Sending probe #1.
sent probes: 1.
tcp_send_empty_ack: sending ACK for 2035920185 rcv ann win 65535
Sending probe #2.
sent probes: 2.
tcp_send_empty_ack: sending ACK for 2035920185 rcv ann win 65535
Sending probe #3.
sent probes: 3.
Resetting connection due Lack of response upon keep alive check.
sent probes: 3.
Resetting connection due Lack of response upon keep alive check.
tcp_send_empty_ack: sending ACK for 2035920197 rcv ann win 65535
mean round-trip time: 36.322 usec
Reporting half round-trip stats in nsec for 500000 iterations
#       size    mean    min     median  max     %ile    stddev  iter
        12      18161   8531636586      998     11027   1947    5907361 500000
tcp_send_empty_ack: sending ACK for 2039713110 rcv ann win 65522
```

1. Expected mean RTT which follows the gap in seconds (~18 sec). 

