### PR TITLE
ON-17429: Fix potential for bad packet data on X3 with multiple RXQs in use

### DIFF
--- a/src/lib/zf/private/reactor.c
+++ b/src/lib/zf/private/reactor.c
@@ -420,7 +420,7 @@ zf_reactor_wait_for_rx_event(struct zf_stack* stack, int nic, pkt_id packet_id,
      * for at least EF_VI_EVENT_POLL_MIN_EVS events, but on EF10 it's safe to
      * ignore this. */
     ef_event ev;
-    unsigned n_ev = ef_eventq_poll(vi, &ev, 1);
+    unsigned n_ev = ef_future_eventq_poll(vi, &ev, 1);
     if( n_ev > 0 ) {
       zf_assume_equal(n_ev, 1);
       auto ev_type = EF_EVENT_TYPE(ev);


### PR DESCRIPTION
On the efct arch we can have multiple RX queues. If we've done future work as a result of peeking a packet from one of them we need poll to pick up the same packet. Using ef_future_eventq_poll uses an appropriate arch specific poll method to keep the future packet consistent. This fixes a potential race condition where a packet arrives on another RXQ between the time at which we do the peek and the time at which we do the poll.